### PR TITLE
tooltip number fix

### DIFF
--- a/src/components/common/ChartTooltip.tsx
+++ b/src/components/common/ChartTooltip.tsx
@@ -19,7 +19,7 @@ const ChartTooltipRow = ({ value, name, color }: ChartTooltipRowProps) => (
             ) } />
             <p className={ classNames(
                 getColorVariantsFromColorThemeValue(defaultColors.darkText).textColor,
-                'font-medium'
+                'font-medium tabular-nums text-right'
             ) }>
                 { value }
             </p>


### PR DESCRIPTION
![CleanShot 2022-07-25 at 01 52 59@2x](https://user-images.githubusercontent.com/41927988/180671059-8697dd37-5df2-4f75-bf78-f42c65763056.png)

This pull request fixes the tooltip component. The displayed data is now in tabular number format and aligned to the right.