### PR TITLE
Chart and bar animations, Metric count up

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@tippyjs/react": "^4.2.6",
         "date-fns": "^2.28.0",
+        "react-countup": "^6.3.1",
         "recharts": "^2.1.10"
       },
       "devDependencies": {
@@ -10029,6 +10030,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/countup.js": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/countup.js/-/countup.js-2.3.2.tgz",
+      "integrity": "sha512-dQ7F/CmKGjaO6cDfhtEXwsKVlXIpJ89dFs8PvkaZH9jBVJ2Z8GU4iwG/qP7MgY8qwr+1skbwR6qecWWQLUzB8Q=="
     },
     "node_modules/cp-file": {
       "version": "7.0.0",
@@ -22032,6 +22038,17 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-countup": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/react-countup/-/react-countup-6.3.1.tgz",
+      "integrity": "sha512-+Bf1caAZHtmVQ5Jmhe2MZuN1cw1CEP5OdeMph9CBwM5K8DEDGmg00AzcN6fO9XolUhqUfiR0pOEiSyngSrHwig==",
+      "dependencies": {
+        "countup.js": "^2.2.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0"
       }
     },
     "node_modules/react-docgen": {
@@ -34801,6 +34818,11 @@
         "yaml": "^1.10.0"
       }
     },
+    "countup.js": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/countup.js/-/countup.js-2.3.2.tgz",
+      "integrity": "sha512-dQ7F/CmKGjaO6cDfhtEXwsKVlXIpJ89dFs8PvkaZH9jBVJ2Z8GU4iwG/qP7MgY8qwr+1skbwR6qecWWQLUzB8Q=="
+    },
     "cp-file": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/cp-file/-/cp-file-7.0.0.tgz",
@@ -44043,6 +44065,14 @@
       "peer": true,
       "requires": {
         "loose-envify": "^1.1.0"
+      }
+    },
+    "react-countup": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/react-countup/-/react-countup-6.3.1.tgz",
+      "integrity": "sha512-+Bf1caAZHtmVQ5Jmhe2MZuN1cw1CEP5OdeMph9CBwM5K8DEDGmg00AzcN6fO9XolUhqUfiR0pOEiSyngSrHwig==",
+      "requires": {
+        "countup.js": "^2.2.0"
       }
     },
     "react-docgen": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "rollup-plugin-terser": "^7.0.2",
         "rollup-plugin-typescript-paths": "^1.3.1",
         "tailwindcss": "^3.0.24",
-        "typescript": "^4.6.3"
+        "typescript": "^4.2.2"
       },
       "peerDependencies": {
         "react": "^18.0.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-typescript-paths": "^1.3.1",
     "tailwindcss": "^3.0.24",
-    "typescript": "^4.6.3"
+    "typescript": "^4.2.2"
   },
   "peerDependencies": {
     "react": "^18.0.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@tippyjs/react": "^4.2.6",
     "date-fns": "^2.28.0",
+    "react-countup": "^6.3.1",
     "recharts": "^2.1.10"
   },
   "devDependencies": {

--- a/src/components/chart-elements/AreaChart/AreaChart.tsx
+++ b/src/components/chart-elements/AreaChart/AreaChart.tsx
@@ -28,6 +28,7 @@ const AreaChart = ({
     showXAxis = true,
     showYAxis = true,
     yAxisWidth = 'w-14',
+    showAnimation = true,
     showTooltip = true,
     showLegend = true,
     showGridLines = true,
@@ -133,7 +134,7 @@ const AreaChart = ({
                         fill={ `url(#${colors[idx]})` }
                         strokeWidth={2}
                         dot={false}
-                        isAnimationActive={false}
+                        isAnimationActive={ showAnimation }
                     />
                 ))}
             </ReChartsAreaChart>

--- a/src/components/chart-elements/BarChart/BarChart.tsx
+++ b/src/components/chart-elements/BarChart/BarChart.tsx
@@ -43,6 +43,7 @@ const BarChart = ({
     showXAxis = true,
     showYAxis = true,
     yAxisWidth = 'w-14',
+    showAnimation = true,
     showTooltip = true,
     showLegend = true,
     showGridLines = true,
@@ -170,7 +171,7 @@ const BarChart = ({
                             stackId={ stack || relative ? 'a' : undefined }
                             dataKey={ category }
                             fill={ getHexFromColorThemeValue(getColorTheme(colors[idx]).background) }
-                            isAnimationActive={false}
+                            isAnimationActive={ showAnimation }
                         />
 
                     ))

--- a/src/components/chart-elements/LineChart/LineChart.tsx
+++ b/src/components/chart-elements/LineChart/LineChart.tsx
@@ -34,6 +34,7 @@ const LineChart = ({
     showXAxis = true,
     showYAxis = true,
     yAxisWidth = 'w-14',
+    showAnimation = true,
     showTooltip = true,
     showLegend = true,
     showGridLines = true,
@@ -123,7 +124,7 @@ const LineChart = ({
                             stroke={ getHexFromColorThemeValue(getColorTheme(colors[idx]).background) }
                             strokeWidth={ 2 }
                             dot={ false }
-                            isAnimationActive={ false }
+                            isAnimationActive={ showAnimation }
                         />
                     )) }
                 </ReChartsLineChart>

--- a/src/components/chart-elements/common/BaseChartProps.tsx
+++ b/src/components/chart-elements/common/BaseChartProps.tsx
@@ -20,6 +20,7 @@ interface BaseChartProps {
     showXAxis?: boolean,
     showYAxis?: boolean,
     yAxisWidth?: Width,
+    showAnimation: boolean,
     showTooltip?: boolean,
     showLegend?: boolean,
     showGridLines?: boolean,

--- a/src/components/chart-elements/common/BaseChartProps.tsx
+++ b/src/components/chart-elements/common/BaseChartProps.tsx
@@ -20,7 +20,7 @@ interface BaseChartProps {
     showXAxis?: boolean,
     showYAxis?: boolean,
     yAxisWidth?: Width,
-    showAnimation: boolean,
+    showAnimation?: boolean,
     showTooltip?: boolean,
     showLegend?: boolean,
     showGridLines?: boolean,

--- a/src/components/text-elements/Metric/Metric.tsx
+++ b/src/components/text-elements/Metric/Metric.tsx
@@ -19,6 +19,7 @@ export interface MetricProps {
     prefix?: string,
     suffix?: string,
     number: number,
+    separator?: string,
     duration?: number
 }
 
@@ -29,6 +30,7 @@ const Metric = ({
     number,
     prefix = '',
     suffix = '',
+    separator = ',',
     duration = 0.5
 }: MetricProps) => {
     return(
@@ -42,12 +44,13 @@ const Metric = ({
             ) }
             >
                 <CountUp 
-                    separator=','
+                    separator={ separator }
                     prefix={ prefix }
                     end={ number }
                     suffix={ suffix }
                     duration={ duration }
                 />
+
             </p>
         </div>
     );

--- a/src/components/text-elements/Metric/Metric.tsx
+++ b/src/components/text-elements/Metric/Metric.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import CountUp from 'react-countup';
 
 import {
     BaseColors,
@@ -15,14 +16,20 @@ export interface MetricProps {
     color?: Color,
     truncate?: boolean,
     marginTop?: MarginTop,
-    children: React.ReactNode,
+    prefix?: string,
+    suffix?: string,
+    number: number,
+    duration?: number
 }
 
 const Metric = ({
     color = BaseColors.Gray,
     truncate = false,
     marginTop = 'mt-0',
-    children,
+    number,
+    prefix = '',
+    suffix = '',
+    duration = 0.5
 }: MetricProps) => {
     return(
         <div className={ classNames(marginTop) }>
@@ -34,7 +41,13 @@ const Metric = ({
                 fontWeight.lg,
             ) }
             >
-                { children }
+                <CountUp 
+                    separator=','
+                    prefix={ prefix }
+                    end={ number }
+                    suffix={ suffix }
+                    duration={ duration }
+                />
             </p>
         </div>
     );

--- a/src/components/vis-elements/CategoryBar/CategoryBar.tsx
+++ b/src/components/vis-elements/CategoryBar/CategoryBar.tsx
@@ -32,7 +32,7 @@ const BarLabels = ({ categoryPercentageValues }: {categoryPercentageValues: numb
                     <div
                         key={ `item-${idx}` }
                         className="flex items-center justify-end"
-                        style={ { 'width': `${widthPercentage}%` } }
+                        style={ { 'width': `${widthPercentage}%`, 'transition': 'all 2s' } }
                     >
                         <span className={
                             classNames(idx === 0 && widthPercentage <= 10 ? 'hidden sm:inline-block' : '')
@@ -112,7 +112,7 @@ const CategoryBar = ({
                                 'absolute right-1/2 -translate-x-1/2',
                                 sizing.lg.width, // wide transparant wrapper for tooltip activation
                             ) }
-                            style={ { 'left': `${percentageValue}%` } }
+                            style={ { 'left': `${percentageValue}%`, 'transition': 'all 2s' } }
                         >
                             <div
                                 className={ classNames(

--- a/src/components/vis-elements/CategoryBar/CategoryBar.tsx
+++ b/src/components/vis-elements/CategoryBar/CategoryBar.tsx
@@ -32,7 +32,7 @@ const BarLabels = ({ categoryPercentageValues }: {categoryPercentageValues: numb
                     <div
                         key={ `item-${idx}` }
                         className="flex items-center justify-end"
-                        style={ { 'width': `${widthPercentage}%`, 'transition': 'all 2s' } }
+                        style={ { 'width': `${widthPercentage}%` } }
                     >
                         <span className={
                             classNames(idx === 0 && widthPercentage <= 10 ? 'hidden sm:inline-block' : '')
@@ -56,6 +56,7 @@ export interface CategoryBarProps {
     percentageValue?: number,
     showLabels?: boolean,
     tooltip?: string,
+    showAnimation?: boolean,
     marginTop?: MarginTop,
 }
 
@@ -65,6 +66,7 @@ const CategoryBar = ({
     percentageValue,
     showLabels = true,
     tooltip,
+    showAnimation = true,
     marginTop = 'mt-0',
 }: CategoryBarProps) => {
 
@@ -112,7 +114,7 @@ const CategoryBar = ({
                                 'absolute right-1/2 -translate-x-1/2',
                                 sizing.lg.width, // wide transparant wrapper for tooltip activation
                             ) }
-                            style={ { 'left': `${percentageValue}%`, 'transition': 'all 2s' } }
+                            style={ { 'left': `${percentageValue}%`, 'transition': showAnimation ? 'all 2s' : '' } }
                         >
                             <div
                                 className={ classNames(

--- a/src/components/vis-elements/DeltaBar/DeltaBar.tsx
+++ b/src/components/vis-elements/DeltaBar/DeltaBar.tsx
@@ -49,7 +49,7 @@ const DeltaBar = ({
                                         isIncreasePositive
                                     )].bgColor,
                                 ) } 
-                                style={ {'width': `${Math.abs(percentageValue)}%`} } 
+                                style={ {'width': `${Math.abs(percentageValue)}%`, 'transition': 'all 2s'} } 
                             />
                         </Tooltip>
                     ) : null}
@@ -73,7 +73,7 @@ const DeltaBar = ({
                                         isIncreasePositive
                                     )].bgColor,
                                 ) } 
-                                style={ {'width': `${Math.abs(percentageValue)}%`} } 
+                                style={ {'width': `${Math.abs(percentageValue)}%`, 'transition': 'all 2s'} } 
                             />
                         </Tooltip>
                     ) : null}

--- a/src/components/vis-elements/DeltaBar/DeltaBar.tsx
+++ b/src/components/vis-elements/DeltaBar/DeltaBar.tsx
@@ -22,6 +22,7 @@ export interface DeltaBarProps {
     percentageValue: number,
     isIncreasePositive?: boolean,
     tooltip?: string,
+    showAnimation?: boolean
     marginTop?: MarginTop,
 }
 
@@ -29,6 +30,7 @@ const DeltaBar = ({
     percentageValue,
     isIncreasePositive = true,
     tooltip,
+    showAnimation = true,
     marginTop = 'mt-0',
 }: DeltaBarProps) => {
     return(
@@ -49,7 +51,7 @@ const DeltaBar = ({
                                         isIncreasePositive
                                     )].bgColor,
                                 ) } 
-                                style={ {'width': `${Math.abs(percentageValue)}%`, 'transition': 'all 2s'} } 
+                                style={ {'width': `${Math.abs(percentageValue)}%`, 'transition': showAnimation ? 'all 2s' : '' } } 
                             />
                         </Tooltip>
                     ) : null}
@@ -73,7 +75,7 @@ const DeltaBar = ({
                                         isIncreasePositive
                                     )].bgColor,
                                 ) } 
-                                style={ {'width': `${Math.abs(percentageValue)}%`, 'transition': 'all 2s'} } 
+                                style={ {'width': `${Math.abs(percentageValue)}%`, 'transition': showAnimation ? 'all 2s' : ''} } 
                             />
                         </Tooltip>
                     ) : null}

--- a/src/components/vis-elements/MarkerBar/MarkerBar.tsx
+++ b/src/components/vis-elements/MarkerBar/MarkerBar.tsx
@@ -34,7 +34,7 @@ const MarkerBar = ({
                         'absolute right-1/2 -translate-x-1/2',
                         sizing.lg.width, // wide transparant wrapper for tooltip activation
                     ) }
-                    style={ { 'left': `${percentageValue}%` } }
+                    style={ { 'left': `${percentageValue}%`, 'transition': 'all 2s'} }
                 >
                     <div
                         className={ classNames(

--- a/src/components/vis-elements/MarkerBar/MarkerBar.tsx
+++ b/src/components/vis-elements/MarkerBar/MarkerBar.tsx
@@ -10,6 +10,7 @@ export interface MarkerBarProps {
     percentageValue: number,
     color?: Color,
     tooltip?: string,
+    showAnimation?: boolean,
     marginTop?: MarginTop,
 }
 
@@ -17,6 +18,7 @@ const MarkerBar = ({
     percentageValue,
     color = BaseColors.Blue,
     tooltip,
+    showAnimation = true,
     marginTop = 'mt-0',
 }: MarkerBarProps) => {
     const primaryBgColor = getColorVariantsFromColorThemeValue(getColorTheme(color).background).bgColor;
@@ -34,7 +36,7 @@ const MarkerBar = ({
                         'absolute right-1/2 -translate-x-1/2',
                         sizing.lg.width, // wide transparant wrapper for tooltip activation
                     ) }
-                    style={ { 'left': `${percentageValue}%`, 'transition': 'all 2s'} }
+                    style={ { 'left': `${percentageValue}%`, 'transition': showAnimation ? 'all 2s' : ''} }
                 >
                     <div
                         className={ classNames(

--- a/src/components/vis-elements/ProgressBar/ProgressBar.tsx
+++ b/src/components/vis-elements/ProgressBar/ProgressBar.tsx
@@ -21,6 +21,7 @@ export interface ProgressBarProps {
     label?: string,
     tooltip?: string,
     color?: Color,
+    showAnimation?: boolean,
     marginTop?: MarginTop,
 }
 
@@ -28,6 +29,7 @@ const ProgressBar = ({
     percentageValue,
     label,
     tooltip,
+    showAnimation = true,
     color = BaseColors.Blue,
     marginTop = 'mt-0',
 }: ProgressBarProps) => {
@@ -51,7 +53,7 @@ const ProgressBar = ({
                             primaryBgColor,
                             'flex-col h-full rounded-lg'
                         ) }
-                        style={ {'width': `${percentageValue}%`, 'transition': 'all 2s'} }
+                        style={ {'width': `${percentageValue}%`, 'transition': showAnimation ? 'all 2s' : ''} }
                     />
                 </Tooltip>
             </div>

--- a/src/components/vis-elements/ProgressBar/ProgressBar.tsx
+++ b/src/components/vis-elements/ProgressBar/ProgressBar.tsx
@@ -51,7 +51,7 @@ const ProgressBar = ({
                             primaryBgColor,
                             'flex-col h-full rounded-lg'
                         ) }
-                        style={ {'width': `${percentageValue}%`} }
+                        style={ {'width': `${percentageValue}%`, 'transition': 'all 2s'} }
                     />
                 </Tooltip>
             </div>

--- a/src/components/vis-elements/RangeBar/RangeBar.tsx
+++ b/src/components/vis-elements/RangeBar/RangeBar.tsx
@@ -38,7 +38,7 @@ const RangeBar = ({
                         'absolute h-full rounded-lg',
                         getColorVariantsFromColorThemeValue(defaultColors.darkBackground).bgColor,
                     ) }
-                    style={ {'left': `${minRangeValue}%`, 'width': `${maxRangeValue - minRangeValue}%`} } 
+                    style={ {'left': `${minRangeValue}%`, 'width': `${maxRangeValue - minRangeValue}%`, 'transition': 'all 2s'} } 
                 />
             </Tooltip>
             <Tooltip content={ markerTooltip } className={ markerTooltip ? '' : 'hidden' }>
@@ -47,7 +47,7 @@ const RangeBar = ({
                         'absolute right-1/2 -translate-x-1/2',
                         sizing.lg.width, // wide transparant wrapper for tooltip activation
                     ) }
-                    style={ { 'left': `${percentageValue}%` } }
+                    style={ { 'left': `${percentageValue}%`, 'transition': 'all 2s' } }
                 >
                     <div
                         className={ classNames(

--- a/src/components/vis-elements/RangeBar/RangeBar.tsx
+++ b/src/components/vis-elements/RangeBar/RangeBar.tsx
@@ -12,6 +12,7 @@ export interface RangeBarProps {
     maxRangeValue: number,
     markerTooltip?: string,
     rangeTooltip?: string,
+    showAnimation: boolean,
     color?: Color,
     marginTop?: MarginTop,
 }
@@ -22,6 +23,7 @@ const RangeBar = ({
     maxRangeValue,
     markerTooltip,
     rangeTooltip,
+    showAnimation = true,
     color = BaseColors.Blue,
     marginTop = 'mt-0',
 }: RangeBarProps) => {
@@ -38,7 +40,7 @@ const RangeBar = ({
                         'absolute h-full rounded-lg',
                         getColorVariantsFromColorThemeValue(defaultColors.darkBackground).bgColor,
                     ) }
-                    style={ {'left': `${minRangeValue}%`, 'width': `${maxRangeValue - minRangeValue}%`, 'transition': 'all 2s'} } 
+                    style={ {'left': `${minRangeValue}%`, 'width': `${maxRangeValue - minRangeValue}%`, 'transition': showAnimation ? 'all 2s' : ''} } 
                 />
             </Tooltip>
             <Tooltip content={ markerTooltip } className={ markerTooltip ? '' : 'hidden' }>
@@ -47,7 +49,7 @@ const RangeBar = ({
                         'absolute right-1/2 -translate-x-1/2',
                         sizing.lg.width, // wide transparant wrapper for tooltip activation
                     ) }
-                    style={ { 'left': `${percentageValue}%`, 'transition': 'all 2s' } }
+                    style={ { 'left': `${percentageValue}%`, 'transition': showAnimation ? 'all 2s' : '' } }
                 >
                     <div
                         className={ classNames(

--- a/src/components/vis-elements/TextBar/TextBar.tsx
+++ b/src/components/vis-elements/TextBar/TextBar.tsx
@@ -63,7 +63,7 @@ const TextBar = ({
                             getColorVariantsFromColorThemeValue(getColorTheme(color).lightBackground).bgColor,
                             idx === data.length - 1 ? spacing.none.marginBottom : spacing.sm.marginBottom,
                         ) }
-                        style={ { width: `${widths[idx]}%` } }
+                        style={ { 'width': `${widths[idx]}%`, 'transition': 'all 2s' } }
                     >
                         <p className={ classNames(
                             'absolute max-w-full whitespace-nowrap truncate',

--- a/src/components/vis-elements/TextBar/TextBar.tsx
+++ b/src/components/vis-elements/TextBar/TextBar.tsx
@@ -34,6 +34,7 @@ export interface TextBarProps {
     data: TextBarData[],
     valueFormater?: ValueFormater,
     color?: Color,
+    showAnimation?: boolean,
     marginTop?: MarginTop,
 }
 
@@ -41,6 +42,7 @@ const TextBar = ({
     data = [],
     color = BaseColors.Blue,
     valueFormater = defaultValueFormater,
+    showAnimation = true,
     marginTop = 'mt-0',
 }: TextBarProps) => {
     const widths = getWidthsFromValues(data);
@@ -63,7 +65,7 @@ const TextBar = ({
                             getColorVariantsFromColorThemeValue(getColorTheme(color).lightBackground).bgColor,
                             idx === data.length - 1 ? spacing.none.marginBottom : spacing.sm.marginBottom,
                         ) }
-                        style={ { 'width': `${widths[idx]}%`, 'transition': 'all 2s' } }
+                        style={ { 'width': `${widths[idx]}%`, 'transition': showAnimation ? 'all 2s' : '' } }
                     >
                         <p className={ classNames(
                             'absolute max-w-full whitespace-nowrap truncate',

--- a/src/stories/Playground.stories.tsx
+++ b/src/stories/Playground.stories.tsx
@@ -26,40 +26,30 @@ export default {
 // More on component templates: https://storybook.js.org/docs/react/writing-stories/introduction#using-args
 
 const Template: ComponentStory<typeof Card> = () => (
-    <div className="grid grid-cols-3 gap-x-3">
-        <Card>
+    <div className="mx-auto">
+        <Card maxWidth='max-w-md'>
             <Flex>
                 <Title>
                     Ticket Sales
                 </Title>
-                <BadgeDelta text="20.1%" deltaType="decrease" isIncreasePositive={ false } />
+                <BadgeDelta text="20.1%" deltaType="increase" isIncreasePositive={ true } />
             </Flex>
             <Subtitle>
                 April 2021
             </Subtitle>
-            <div style={{'marginTop': '10px'}}>
-                <Metric>
-                    21.345
-                </Metric>
-            </div>
-            <Text>
-                Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the
-                industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type
-                and scrambled it to make a type specimen book. It has survived not only five centuries, but also the
-                leap into electronic typesetting, remaining essentially unchanged.
+            <Metric marginTop='mt-2' prefix='$ ' number={250000}/>
+            <Text marginTop='mt-4'>
+                Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type
+                and scrambled it to make a type specimen book. 
             </Text>
-            <div style={{'marginTop': '20px'}}>
-                <Flex>
-                    <Flex justifyContent="justify-start" alignItems="items-baseline" spaceX="space-x-2">
-                        <Text>12.3%</Text>
-                        <Text>E 20.000</Text>
-                    </Flex>
-                    <Text truncate={ true }>$ 20.000 USD</Text>
+            <Flex marginTop='mt-4'>
+                <Flex justifyContent="justify-start" alignItems="items-baseline" spaceX="space-x-2">
+                    <Text>25%</Text>
+                    <Text>($ 250,000)</Text>
                 </Flex>
-            </div>
-            <div style={{'marginTop': '5px'}}>
-                <ProgressBar percentageValue={50} />
-            </div>
+                <Text>$ 1,000,000</Text>
+            </Flex>
+            <ProgressBar marginTop="mt-2" percentageValue={50} showAnimation={true} />
             <Footer>
                 <Flex justifyContent="justify-end" spaceX="space-x-2">
                     <Button text="Button Text" handleClick={handleClick} size="xs" importance="secondary" />
@@ -67,75 +57,38 @@ const Template: ComponentStory<typeof Card> = () => (
                 </Flex>
             </Footer>
         </Card>
-        <Card>
+        {/* <Card>
             <Flex>
                 <Title>
                     Ticket Sales
                 </Title>
-                <BadgeDelta text="20.1%" deltaType="decrease" isIncreasePositive={ false } />
+                <BadgeDelta text="8.1%" deltaType="moderateIncrease" isIncreasePositive={ true } />
             </Flex>
             <Subtitle>
                 April 2021
             </Subtitle>
-            <div style={{'marginTop': '10px'}}>
-                <Metric>
-                    21.345
-                </Metric>
-            </div>
-            <Text>
-                Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the 
+            <Metric marginTop='mt-2' prefix='$ ' number={3500} separator="," />
+            <Text marginTop='mt-4'>
+                Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type
+                and scrambled it to make a type specimen book. 
             </Text>
-            <div style={{'marginTop': '20px'}}>
-                <Flex>
-                    <Flex justifyContent="justify-start" alignItems="items-baseline" spaceX="space-x-2">
-                        <Text>20.000</Text>
-                    </Flex>
-                    <Text>20.000</Text>
+            <Flex marginTop='mt-4'>
+                <Flex justifyContent="justify-start" alignItems="items-baseline" spaceX="space-x-2">
+                    <Text>12.3%</Text>
+                    <Text>($ 200)</Text>
                 </Flex>
-                <div style={{'marginTop': '5px'}}>
-                    <ProgressBar percentageValue={50} />
-                </div>
-            </div>
-            <Footer>
-                <Button text="Button Text" handleClick={handleClick} size="xs" />
-            </Footer>
-        </Card>
-        <Card>
-            <Flex>
-                <Title>
-                    Ticket Sales
-                </Title>
-                <BadgeDelta text="20.1%" deltaType="decrease" isIncreasePositive={ false } />
+                <Text>$ 20,000</Text>
             </Flex>
-            <Subtitle>
-                April 2021
-            </Subtitle>
-            <div style={{'marginTop': '10px'}}>
-                <Metric>
-                    21.345
-                </Metric>
-            </div>
-            <Text>
-                Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the 
-                industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type 
-                and scrambled it to make a type specimen book. It has survived not only five centuries, but also the
-                leap into electronic typesetting, remaining essentially unchanged.
-            </Text>
-            <div style={{'marginTop': '20px'}}>
-                <Flex>
-                    <Flex justifyContent="justify-start" alignItems="items-baseline" spaceX="space-x-2">
-                        <Text>20.000</Text>
-                    </Flex>
-                    <Text>20.000</Text>
-                </Flex>
-                <div style={{'marginTop': '5px'}}>
-                    <DeltaBar percentageValue={75} />
-                </div>
+            <div style={{'marginTop': '5px'}}>
+                <DeltaBar percentageValue={75} />
             </div>
             <Footer>
-                <Button text="Button Text" handleClick={handleClick} size="xs" />
+                <Flex justifyContent="justify-end" spaceX="space-x-2">
+                    <Button text="Button Text" handleClick={handleClick} size="xs" importance="secondary" />
+                    <Button text="Button Text" handleClick={handleClick} size="xs" />
+                </Flex>
             </Footer>
-        </Card>
+        </Card> */}
     </div>
 );
   

--- a/src/stories/text-elements/Metric.stories.tsx
+++ b/src/stories/text-elements/Metric.stories.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 import { BaseColors } from 'lib/primitives';
 import Metric from '../../components/text-elements/Metric/Metric';
+import Card from '../../components/layout-elements/Card/Card';
 
 // More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 export default {
@@ -13,11 +14,9 @@ export default {
 
 const Template: ComponentStory<typeof Metric> = () => (
     <>
-        { Object.values(BaseColors).map(color => (
-            <Metric color={ color }>
-                USD 70,000.00
-            </Metric>
-        ))}
+       <Card maxWidth='max-w-md'>
+            <Metric number={70000} prefix='CHF '/>
+        </Card>
     </>
 );
   

--- a/src/tremor.css
+++ b/src/tremor.css
@@ -1,3 +1,5 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+


### PR DESCRIPTION
1) Added loading animation for data bars, animation does not work in <TextBar/>
2) Added count-up animation (requires dependency react-countup):
   - To-Do I: ensure that animation is also able to count down, e.g. first number display is 70,000, after using datepicker selection the number will be 30,000 --> animation should countdown from 70,000 to 30,000 and not start from 0 again (default start value)
   - To-Do II: animation in data bars should also run when bar is rendered/loaded the first time (filling from 0 to current value)
   
Link to doc: https://www.npmjs.com/package/react-countup#useeasing-boolean
