### PR TITLE
test: Incorrect props in tests

### DIFF
--- a/src/tests/input-elements/Dropdown.test.tsx
+++ b/src/tests/input-elements/Dropdown.test.tsx
@@ -8,9 +8,9 @@ describe('Dropdown', () => {
     test('renders the Dropdown component with default props', () => {
         render(
             <Dropdown>
-                <DropdownItem value={ 5 } name={ 'Five' } />
-                <DropdownItem value={ 3 } name={ 'Three' } />
-                <DropdownItem value={ 1 } name={ 'One' } />
+                <DropdownItem value={5} text={'Five'} />
+                <DropdownItem value={3} text={'Three'} />
+                <DropdownItem value={1} text={'One'} />
             </Dropdown>
         );
     });

--- a/src/tests/input-elements/MultiSelectBox.test.tsx
+++ b/src/tests/input-elements/MultiSelectBox.test.tsx
@@ -8,9 +8,9 @@ describe('SelectBox', () => {
     test('renders the SelectBox component with default props', () => {
         render(
             <MultiSelectBox>
-                <MultiSelectBoxItem value={1} name="Option One" />
-                <MultiSelectBoxItem value={2} name="Option Two" />
-                <MultiSelectBoxItem value={3} name="Option Three" />
+                <MultiSelectBoxItem value={1} text="Option One" />
+                <MultiSelectBoxItem value={2} text="Option Two" />
+                <MultiSelectBoxItem value={3} text="Option Three" />
             </MultiSelectBox>
         );
     });

--- a/src/tests/input-elements/SelectBox.test.tsx
+++ b/src/tests/input-elements/SelectBox.test.tsx
@@ -8,9 +8,9 @@ describe('SelectBox', () => {
     test('renders the SelectBox component with default props', () => {
         render(
             <SelectBox>
-                <SelectBoxItem value={1} name="Option One" />
-                <SelectBoxItem value={2} name="Option Two" />
-                <SelectBoxItem value={3} name="Option Three" />
+                <SelectBoxItem value={1} text="Option One" />
+                <SelectBoxItem value={2} text="Option Two" />
+                <SelectBoxItem value={3} text="Option Three" />
             </SelectBox>
         );
     });

--- a/src/tests/input-elements/Tabs.test.tsx
+++ b/src/tests/input-elements/Tabs.test.tsx
@@ -8,9 +8,9 @@ describe('SelectBox', () => {
     test('renders the SelectBox component with default props', () => {
         render(
             <TabList>
-                <Tab value={1} name="Option One" />
-                <Tab value={2} name="Option Two" />
-                <Tab value={3} name="Option Three" />
+                <Tab value={1} text="Option One" />
+                <Tab value={2} text="Option Two" />
+                <Tab value={3} text="Option Three" />
             </TabList>
         );
     });

--- a/src/tests/vis-elements/RangeBar.test.tsx
+++ b/src/tests/vis-elements/RangeBar.test.tsx
@@ -9,8 +9,8 @@ describe('RangeBar', () => {
         render(
             <RangeBar
                 percentageValue={50}
-                minRangeValue={25}
-                maxRangeValue={75}
+                minPercentageValue={25}
+                maxPercentageValue={75}
             />
         );
     });


### PR DESCRIPTION
Dropdown, MultiSelect, Select, Tabs and RangeBar all were using what I am assuming are old and outdated props. This PR aims to fix them.

Fixes #93 