### PR TITLE
feat: Adding props size to the Legend component

### DIFF
--- a/src/components/text-elements/Legend/Legend.tsx
+++ b/src/components/text-elements/Legend/Legend.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Color, MarginTop } from '../../../lib';
+import { Color, MarginTop, Size } from '../../../lib';
 import {
     classNames,
     defaultColors,
@@ -17,11 +17,15 @@ import {
 export interface LegendItemProps {
     name: string,
     color: Color,
+    labelSize: Size,
+    roundSize: Size,
 }
 
 const LegendItem = ({
     name,
     color,
+    labelSize,
+    roundSize,
 }: LegendItemProps) => (
     <li className={ classNames(
         'tr-inline-flex tr-items-center tr-truncate',
@@ -33,9 +37,9 @@ const LegendItem = ({
             className={ classNames(
                 'tr-flex-none',
                 getColorVariantsFromColorThemeValue(getColorTheme(color).text).textColor,
-                sizing.xs.height,
-                sizing.xs.width,
-                spacing.xs.marginRight,
+                sizing[roundSize].height,
+                sizing[roundSize].width,
+                spacing[roundSize].marginRight,
             ) }
             fill="currentColor"
             viewBox="0 0 8 8"
@@ -44,7 +48,7 @@ const LegendItem = ({
         </svg>
         <p className={ classNames(
             'tr-whitespace-nowrap tr-truncate',
-            fontSize.sm,
+            fontSize[labelSize],
             fontWeight.sm,
         ) }>
             { name }
@@ -57,18 +61,28 @@ export interface LegendProps {
     categories: string[],
     colors?: Color[],
     marginTop?: MarginTop,
+    labelSize?: Size,
+    roundSize?: Size,
 }
 
 const Legend = ({
     categories,
     colors = themeColorRange,
     marginTop = 'mt-0',
+    labelSize = 'sm',
+    roundSize = 'xs',
 }: LegendProps) => {
     return(
         <div className={ classNames(parseMarginTop(marginTop)) }>
             <ol className="tr-flex tr-flex-wrap tr-overflow-hidden tr-truncate">
                 { categories.map((category, idx) => (
-                    <LegendItem key={ `item-${idx}` } name={ category } color={ colors[idx] } />
+                    <LegendItem
+                        key={ `item-${idx}` }
+                        name={ category }
+                        color={ colors[idx] }
+                        labelSize={labelSize}
+                        roundSize={roundSize}
+                    />
                 )) }
             </ol>
         </div>

--- a/src/components/text-elements/Legend/Legend.tsx
+++ b/src/components/text-elements/Legend/Legend.tsx
@@ -18,14 +18,14 @@ export interface LegendItemProps {
     name: string,
     color: Color,
     labelSize: Size,
-    roundSize: Size,
+    circleSize: Size,
 }
 
 const LegendItem = ({
     name,
     color,
     labelSize,
-    roundSize,
+    circleSize,
 }: LegendItemProps) => (
     <li className={ classNames(
         'tr-inline-flex tr-items-center tr-truncate',
@@ -37,9 +37,9 @@ const LegendItem = ({
             className={ classNames(
                 'tr-flex-none',
                 getColorVariantsFromColorThemeValue(getColorTheme(color).text).textColor,
-                sizing[roundSize].height,
-                sizing[roundSize].width,
-                spacing[roundSize].marginRight,
+                sizing[circleSize].height,
+                sizing[circleSize].width,
+                spacing[circleSize].marginRight,
             ) }
             fill="currentColor"
             viewBox="0 0 8 8"
@@ -62,7 +62,7 @@ export interface LegendProps {
     colors?: Color[],
     marginTop?: MarginTop,
     labelSize?: Size,
-    roundSize?: Size,
+    circleSize?: Size,
 }
 
 const Legend = ({
@@ -70,7 +70,7 @@ const Legend = ({
     colors = themeColorRange,
     marginTop = 'mt-0',
     labelSize = 'sm',
-    roundSize = 'xs',
+    circleSize = 'xs',
 }: LegendProps) => {
     return(
         <div className={ classNames(parseMarginTop(marginTop)) }>
@@ -81,7 +81,7 @@ const Legend = ({
                         name={ category }
                         color={ colors[idx] }
                         labelSize={labelSize}
-                        roundSize={roundSize}
+                        circleSize={circleSize}
                     />
                 )) }
             </ol>


### PR DESCRIPTION
I made the adjustment to change the Legend's size:

It is now possible to change the size of the round and also the text.
There are two new features:
- labelSize 
- roundSize

This will allow you to put a larger legend at the bottom of the page for example
<img width="689" alt="Capture d’écran 2022-10-12 à 07 48 42" src="https://user-images.githubusercontent.com/29232471/195260452-02f34a13-f955-4461-a722-1586b4df23d7.png">

Fixes #90 
