### PR TITLE
feat: Reference Lines in Chart

### DIFF
--- a/src/components/chart-elements/AreaChart/AreaChart.tsx
+++ b/src/components/chart-elements/AreaChart/AreaChart.tsx
@@ -9,6 +9,7 @@ import {
     Tooltip,
     XAxis,
     YAxis,
+    ReferenceLine
 } from 'recharts';
 
 import BaseChartProps from '../common/BaseChartProps';
@@ -44,6 +45,8 @@ const AreaChart = ({
     showGradient = true,
     height = 'h-80',
     marginTop = 'mt-0',
+    showReferenceLines = false,
+    referenceLines = []
 }: BaseChartProps) => {
     const [legendHeight, setLegendHeight] = useState(60);
     const categoryColors = constructCategoryColors(categories, colors);
@@ -111,6 +114,34 @@ const AreaChart = ({
                             position={ { y: 0 } }
                         />
                     ) : null }
+
+                    {showReferenceLines ? (
+                        <>
+                            { referenceLines.map(({
+                                x, 
+                                y, 
+                                alwaysShow, 
+                                label, 
+                                isFront, 
+                                strokeWidth, 
+                                segment, 
+                                strokeDasharray, 
+                                stroke
+                            }) => (
+                                <ReferenceLine 
+                                    x={x}
+                                    y={y}
+                                    label={label}
+                                    alwaysShow={alwaysShow}
+                                    isFront={isFront}
+                                    strokeWidth={strokeWidth}
+                                    segment={segment}
+                                    strokeDasharray={strokeDasharray}
+                                    stroke={stroke}/>
+                            ))}
+                        </>
+                    ) : null}
+
                     { showLegend ? (
                         <Legend
                             verticalAlign="top"

--- a/src/components/chart-elements/AreaChart/AreaChart.tsx
+++ b/src/components/chart-elements/AreaChart/AreaChart.tsx
@@ -5,11 +5,11 @@ import {
     CartesianGrid,
     Legend,
     AreaChart as ReChartsAreaChart,
+    ReferenceLine,
     ResponsiveContainer,
     Tooltip,
     XAxis,
-    YAxis,
-    ReferenceLine
+    YAxis
 } from 'recharts';
 
 import BaseChartProps from '../common/BaseChartProps';

--- a/src/components/chart-elements/BarChart/BarChart.tsx
+++ b/src/components/chart-elements/BarChart/BarChart.tsx
@@ -5,11 +5,11 @@ import {
     CartesianGrid,
     Legend,
     BarChart as ReChartsBarChart,
+    ReferenceLine,
     ResponsiveContainer,
     Tooltip,
     XAxis,
-    YAxis,
-    ReferenceLine
+    YAxis
 } from 'recharts';
 
 import BaseChartProps from '../common/BaseChartProps';

--- a/src/components/chart-elements/BarChart/BarChart.tsx
+++ b/src/components/chart-elements/BarChart/BarChart.tsx
@@ -9,6 +9,7 @@ import {
     Tooltip,
     XAxis,
     YAxis,
+    ReferenceLine
 } from 'recharts';
 
 import BaseChartProps from '../common/BaseChartProps';
@@ -52,6 +53,8 @@ const BarChart = ({
     showGridLines = true,
     height = 'h-80',
     marginTop = 'mt-0',
+    showReferenceLines = false,
+    referenceLines = []
 }: BarChartProps) => {
     const [legendHeight, setLegendHeight] = useState(60);
     const categoryColors = constructCategoryColors(categories, colors);
@@ -162,6 +165,34 @@ const BarChart = ({
                             position={{ y: 0 }}
                         />
                     ) : null }
+
+                    {showReferenceLines ? (
+                        <>
+                            { referenceLines.map(({
+                                x,
+                                y,
+                                alwaysShow,
+                                label,
+                                isFront,
+                                strokeWidth,
+                                segment,
+                                strokeDasharray,
+                                stroke
+                            }) => (
+                                <ReferenceLine 
+                                    x={x}
+                                    y={y}
+                                    label={label}
+                                    alwaysShow={alwaysShow}
+                                    isFront={isFront}
+                                    strokeWidth={strokeWidth}
+                                    segment={segment}
+                                    strokeDasharray={strokeDasharray}
+                                    stroke={stroke}/>
+                            ))}
+                        </>
+                    ) : null}
+
                     {
                         showLegend ? (
                             <Legend

--- a/src/components/chart-elements/LineChart/LineChart.tsx
+++ b/src/components/chart-elements/LineChart/LineChart.tsx
@@ -5,11 +5,11 @@ import {
     Legend,
     Line,
     LineChart as ReChartsLineChart,
+    ReferenceLine,
     ResponsiveContainer,
     Tooltip,
     XAxis,
-    YAxis,
-    ReferenceLine
+    YAxis
 } from 'recharts';
 
 import BaseChartProps from '../common/BaseChartProps';

--- a/src/components/chart-elements/LineChart/LineChart.tsx
+++ b/src/components/chart-elements/LineChart/LineChart.tsx
@@ -9,6 +9,7 @@ import {
     Tooltip,
     XAxis,
     YAxis,
+    ReferenceLine
 } from 'recharts';
 
 import BaseChartProps from '../common/BaseChartProps';
@@ -43,6 +44,8 @@ const LineChart = ({
     showGridLines = true,
     height = 'h-80',
     marginTop = 'mt-0',
+    showReferenceLines = false,
+    referenceLines = []
 }: BaseChartProps) => {
     const [legendHeight, setLegendHeight] = useState(60);
     const categoryColors = constructCategoryColors(categories, colors);
@@ -110,6 +113,34 @@ const LineChart = ({
                             position={{ y: 0 }}
                         />
                     ) : null }
+
+                    {showReferenceLines ? (
+                        <>
+                            { referenceLines.map(({
+                                x, 
+                                y, 
+                                alwaysShow, 
+                                label, 
+                                isFront, 
+                                strokeWidth, 
+                                segment, 
+                                strokeDasharray, 
+                                stroke
+                            }) => (
+                                <ReferenceLine 
+                                    x={x}
+                                    y={y}
+                                    label={label}
+                                    alwaysShow={alwaysShow}
+                                    isFront={isFront}
+                                    strokeWidth={strokeWidth}
+                                    segment={segment}
+                                    strokeDasharray={strokeDasharray}
+                                    stroke={stroke}/>
+                            ))}
+                        </>
+                    ) : null}
+
                     { showLegend ? (
                         <Legend
                             verticalAlign="top"

--- a/src/components/chart-elements/common/BaseChartProps.tsx
+++ b/src/components/chart-elements/common/BaseChartProps.tsx
@@ -5,7 +5,7 @@ import {
     ValueFormatter,
     Width,
 } from '../../../lib';
-import { ChartReferenceLineProps } from './ChartReferenceLine';
+import { ChartReferenceLineProps } from './ChartReferenceLineProps';
 
 
 interface BaseChartProps {

--- a/src/components/chart-elements/common/BaseChartProps.tsx
+++ b/src/components/chart-elements/common/BaseChartProps.tsx
@@ -5,6 +5,8 @@ import {
     ValueFormatter,
     Width,
 } from '../../../lib';
+import { ChartReferenceLineProps } from './ChartReferenceLine';
+
 
 interface BaseChartProps {
     data: any[],
@@ -23,6 +25,8 @@ interface BaseChartProps {
     showGridLines?: boolean,
     height?: Height,
     marginTop?: MarginTop,
+    showReferenceLines: boolean,
+    referenceLines?: ChartReferenceLineProps[];
 }
 
 export default BaseChartProps;

--- a/src/components/chart-elements/common/ChartReferenceLineProps.tsx
+++ b/src/components/chart-elements/common/ChartReferenceLineProps.tsx
@@ -1,11 +1,22 @@
+import { ReactElement } from 'react';
+
 export interface ChartReferenceLineProps {
   x?: string | number;
   y?: string | number;
   alwaysShow?: boolean;
-  label: any;
+  label: string | number | ReactElement | Function;
   isFront?: boolean;
   strokeWidth?: number;
-  segment?: any;
+  segment?: [
+    {
+      x: string | number,
+      y: string | number,
+    },
+    {
+      x: string | number,
+      y: string | number,
+    }
+  ];
   strokeDasharray?: string;
   stroke?: string;
 }

--- a/src/components/chart-elements/common/ChartReferenceLineProps.tsx
+++ b/src/components/chart-elements/common/ChartReferenceLineProps.tsx
@@ -1,0 +1,11 @@
+export interface ChartReferenceLineProps {
+  x?: string | number;
+  y?: string | number;
+  alwaysShow?: boolean;
+  label: any;
+  isFront?: boolean;
+  strokeWidth?: number;
+  segment?: any;
+  strokeDasharray?: string;
+  stroke?: string;
+}

--- a/src/components/chart-elements/common/ChartReferenceLineProps.tsx
+++ b/src/components/chart-elements/common/ChartReferenceLineProps.tsx
@@ -4,7 +4,7 @@ export interface ChartReferenceLineProps {
   x?: string | number;
   y?: string | number;
   alwaysShow?: boolean;
-  label: string | number | ReactElement | Function;
+  label: string | number | ReactElement;
   isFront?: boolean;
   strokeWidth?: number;
   segment?: [

--- a/src/stories/chart-elements/AreaChart.stories.tsx
+++ b/src/stories/chart-elements/AreaChart.stories.tsx
@@ -123,3 +123,16 @@ WithNoDataKey.args = {
     data: data,
     categories: [ 'Sales', 'Successfull Payments' ],
 };
+
+export const WithReferenceLines = DefaultTemplate.bind({});
+WithReferenceLines.args = {
+    data: data,
+    categories: [ 'Sales', 'Successfull Payments' ],
+    dataKey: 'month',
+    showReferenceLines: true,
+    referenceLines: [ 
+        { x: "Mar 21\'", stroke: "green", label:"Min PAGE" },
+        { y: 2500, label: "Avg", stroke: "red", strokeDasharray: "3 3" },
+        { label: "Segment", stroke: "green", strokeDasharray: "3 3", segment: [{ x: 'Feb 21\'', y: 0 }, { x: 'May 21\'', y: 4000 }]}
+    ]
+};

--- a/src/stories/chart-elements/AreaChart.stories.tsx
+++ b/src/stories/chart-elements/AreaChart.stories.tsx
@@ -131,8 +131,13 @@ WithReferenceLines.args = {
     dataKey: 'month',
     showReferenceLines: true,
     referenceLines: [ 
-        { x: "Mar 21\'", stroke: "green", label:"Min PAGE" },
-        { y: 2500, label: "Avg", stroke: "red", strokeDasharray: "3 3" },
-        { label: "Segment", stroke: "green", strokeDasharray: "3 3", segment: [{ x: 'Feb 21\'', y: 0 }, { x: 'May 21\'', y: 4000 }]}
+        { x: 'Mar 21\'', stroke: 'green', label:'Min PAGE' },
+        { y: 2500, label: 'Avg', stroke: 'red', strokeDasharray: '3 3' },
+        {
+            label: 'Segment',
+            stroke: 'green',
+            strokeDasharray: '3 3',
+            segment: [{ x: 'Feb 21\'', y: 0 }, { x: 'May 21\'', y: 4000 }]
+        }
     ]
 };

--- a/src/stories/chart-elements/BarChart.stories.tsx
+++ b/src/stories/chart-elements/BarChart.stories.tsx
@@ -160,12 +160,12 @@ WithReferenceLines.args = {
     dataKey: 'month',
     showReferenceLines: true,
     referenceLines: [ 
-        { x: "Mar 21\'", stroke: "green", label:"Min PAGE", isFront: true },
-        { y: 2500, label: "Avg", stroke: "red", strokeDasharray: "3 3", isFront: true },
+        { x: 'Mar 21\'', stroke: 'green', label:'Min PAGE', isFront: true },
+        { y: 2500, label: 'Avg', stroke: 'red', strokeDasharray: '3 3', isFront: true },
         { 
-            label: "Segment",
-            stroke: "green",
-            strokeDasharray: "3 3",
+            label: 'Segment',
+            stroke: 'green',
+            strokeDasharray: '3 3',
             segment: [
                 { x: 'Feb 21\'', y: 0 },
                 { x: 'May 21\'', y: 4000 }

--- a/src/stories/chart-elements/BarChart.stories.tsx
+++ b/src/stories/chart-elements/BarChart.stories.tsx
@@ -151,3 +151,26 @@ WithNoDataKey.args = {
     data: data,
     categories: [ 'Sales', 'Successfull Payments' ],
 };
+
+
+export const WithReferenceLines = DefaultTemplate.bind({});
+WithReferenceLines.args = {
+    data: data,
+    categories: [ 'Sales', 'Successfull Payments' ],
+    dataKey: 'month',
+    showReferenceLines: true,
+    referenceLines: [ 
+        { x: "Mar 21\'", stroke: "green", label:"Min PAGE", isFront: true },
+        { y: 2500, label: "Avg", stroke: "red", strokeDasharray: "3 3", isFront: true },
+        { 
+            label: "Segment",
+            stroke: "green",
+            strokeDasharray: "3 3",
+            segment: [
+                { x: 'Feb 21\'', y: 0 },
+                { x: 'May 21\'', y: 4000 }
+            ],
+            isFront: true,
+        }
+    ]
+};

--- a/src/stories/chart-elements/LineChart.stories.tsx
+++ b/src/stories/chart-elements/LineChart.stories.tsx
@@ -123,3 +123,16 @@ WithNoDataKey.args = {
     data: data,
     categories: [ 'Sales', 'Successfull Payments' ],
 };
+
+export const WithReferenceLines = DefaultTemplate.bind({});
+WithReferenceLines.args = {
+    data: data,
+    categories: [ 'Sales', 'Successfull Payments' ],
+    dataKey: 'month',
+    showReferenceLines: true,
+    referenceLines: [ 
+        { x: "Mar 21\'", stroke: "green", label:"Min PAGE" },
+        { y: 2500, label: "Avg", stroke: "red", strokeDasharray: "3 3" },
+        { label: "Segment", stroke: "green", strokeDasharray: "3 3", segment: [{ x: 'Feb 21\'', y: 0 }, { x: 'May 21\'', y: 4000 }]}
+    ]
+};

--- a/src/stories/chart-elements/LineChart.stories.tsx
+++ b/src/stories/chart-elements/LineChart.stories.tsx
@@ -131,8 +131,13 @@ WithReferenceLines.args = {
     dataKey: 'month',
     showReferenceLines: true,
     referenceLines: [ 
-        { x: "Mar 21\'", stroke: "green", label:"Min PAGE" },
-        { y: 2500, label: "Avg", stroke: "red", strokeDasharray: "3 3" },
-        { label: "Segment", stroke: "green", strokeDasharray: "3 3", segment: [{ x: 'Feb 21\'', y: 0 }, { x: 'May 21\'', y: 4000 }]}
+        { x: 'Mar 21\'', stroke: 'green', label:'Min PAGE' },
+        { y: 2500, label: 'Avg', stroke: 'red', strokeDasharray: '3 3' },
+        {
+            label: 'Segment',
+            stroke: 'green',
+            strokeDasharray: '3 3',
+            segment: [{ x: 'Feb 21\'', y: 0 }, { x: 'May 21\'', y: 4000 }]
+        }
     ]
 };

--- a/src/stories/chart-elements/helpers/testData.tsx
+++ b/src/stories/chart-elements/helpers/testData.tsx
@@ -28,7 +28,7 @@ export const data = [
         'Test': 5000,
     },
     {
-        month: 'May 21',
+        month: 'May 21\'',
         Sales: 1890,
         'Successfull Payments': 1000,
         'This is an edge case': 100000000,


### PR DESCRIPTION
**What** - Additional reference lines on Area, Bar and Line charts
**Why** - This adds more information to the above mentioned charts
**How** - Leveraged `ReferenceLine` component from the `Recharts` library to achieve the result
**Testing** - Updated stories to reflect same usage

This should fix https://github.com/tremorlabs/tremor/issues/121 issue.

Sample screenshots
<img width="1429" alt="Screenshot 2022-11-01 at 8 26 42 PM" src="https://user-images.githubusercontent.com/2352166/199335541-ae6425b3-15ab-49fa-aa47-56aa8789f324.png">