### PR TITLE
feat: add prop to manually set the button type

### DIFF
--- a/src/components/input-elements/Button/Button.tsx
+++ b/src/components/input-elements/Button/Button.tsx
@@ -25,6 +25,7 @@ import {
 
 export interface ButtonProps {
     text: string,
+    type?: React.ButtonHTMLAttributes<HTMLButtonElement>["type"],
     icon?: React.ElementType,
     iconPosition?: HorizontalPosition,
     size?: Size,
@@ -40,6 +41,7 @@ const Button = ({
     icon,
     iconPosition = HorizontalPositions.Left,
     handleClick,
+    type = "button",
     size = Sizes.SM,
     color = BaseColors.Blue,
     importance = Importances.Primary,
@@ -53,7 +55,7 @@ const Button = ({
     return (
         <div className={ classNames('tremor-base', parseMarginTop(marginTop)) }>
             <button
-                type="button"
+                type={type}
                 onClick={ handleClick }
                 className={ classNames(
                     'input-elem tr-flex-shrink-0 tr-inline-flex tr-items-center tr-group',

--- a/src/components/input-elements/ButtonInline/ButtonInline.tsx
+++ b/src/components/input-elements/ButtonInline/ButtonInline.tsx
@@ -17,6 +17,7 @@ import { buttonProportions, iconSizes } from './styles';
 
 export interface ButtonInlineProps {
     text: string,
+    type?: React.ButtonHTMLAttributes<HTMLButtonElement>["type"],
     icon?: React.ElementType,
     iconPosition?: HorizontalPosition,
     size?: Size,
@@ -28,6 +29,7 @@ export interface ButtonInlineProps {
 
 const ButtonInline = ({
     text,
+    type = "button",
     icon,
     iconPosition = HorizontalPositions.Left,
     handleClick,
@@ -41,7 +43,7 @@ const ButtonInline = ({
     return (
         <span className={classNames('tremor-base', parseMarginTop(marginTop))}>
             <button
-                type="button"
+                type={type}
                 onClick={handleClick}
                 className={classNames(
                     'input-elem tr-flex-shrink-0 tr-inline-flex tr-items-center tr-group tr-font-medium',


### PR DESCRIPTION
When I wanted to use the button to submit a form, I found that this is not possible at the moment, because I couldn't set `type="submit"` as prop, which is necessary to trigger a form submit using the button.

I added the optional `type` prop to `<Button>` and `<ButtonInline>`. 
The current default behaviour does not change, since the default `type` remains the same (`"text"`), but now you can optionally choose to trigger form submits or form resets using the prop.