### PR TITLE
feat: Add stacked option to area

### DIFF
--- a/src/components/chart-elements/AreaChart/AreaChart.tsx
+++ b/src/components/chart-elements/AreaChart/AreaChart.tsx
@@ -44,6 +44,7 @@ const AreaChart = ({
     showGradient = true,
     height = 'h-80',
     marginTop = 'mt-0',
+    stacked = false,
 }: BaseChartProps) => {
     const [legendHeight, setLegendHeight] = useState(60);
     const categoryColors = constructCategoryColors(categories, colors);
@@ -162,6 +163,7 @@ const AreaChart = ({
                             strokeWidth={2}
                             dot={false}
                             isAnimationActive={ showAnimation }
+                            stackId={ stacked ? 'a' : undefined }
                         />
                     ))}
                 

--- a/src/components/chart-elements/AreaChart/AreaChart.tsx
+++ b/src/components/chart-elements/AreaChart/AreaChart.tsx
@@ -27,6 +27,10 @@ import {
     themeColorRange
 } from 'lib';
 
+export interface AreaChartProps extends BaseChartProps {
+    stack?: boolean,
+}
+
 const AreaChart = ({
     data = [],
     categories = [],
@@ -44,8 +48,8 @@ const AreaChart = ({
     showGradient = true,
     height = 'h-80',
     marginTop = 'mt-0',
-    stacked = false,
-}: BaseChartProps) => {
+    stack = false,
+}: AreaChartProps) => {
     const [legendHeight, setLegendHeight] = useState(60);
     const categoryColors = constructCategoryColors(categories, colors);
 
@@ -163,7 +167,7 @@ const AreaChart = ({
                             strokeWidth={2}
                             dot={false}
                             isAnimationActive={ showAnimation }
-                            stackId={ stacked ? 'a' : undefined }
+                            stackId={ stack ? 'a' : undefined }
                         />
                     ))}
                 

--- a/src/components/chart-elements/common/BaseChartProps.tsx
+++ b/src/components/chart-elements/common/BaseChartProps.tsx
@@ -23,6 +23,7 @@ interface BaseChartProps {
     showGridLines?: boolean,
     height?: Height,
     marginTop?: MarginTop,
+    stacked: boolean,
 }
 
 export default BaseChartProps;

--- a/src/components/chart-elements/common/BaseChartProps.tsx
+++ b/src/components/chart-elements/common/BaseChartProps.tsx
@@ -23,7 +23,6 @@ interface BaseChartProps {
     showGridLines?: boolean,
     height?: Height,
     marginTop?: MarginTop,
-    stacked?: boolean,
 }
 
 export default BaseChartProps;

--- a/src/components/chart-elements/common/BaseChartProps.tsx
+++ b/src/components/chart-elements/common/BaseChartProps.tsx
@@ -23,7 +23,7 @@ interface BaseChartProps {
     showGridLines?: boolean,
     height?: Height,
     marginTop?: MarginTop,
-    stacked: boolean,
+    stacked?: boolean,
 }
 
 export default BaseChartProps;

--- a/src/stories/chart-elements/AreaChart.stories.tsx
+++ b/src/stories/chart-elements/AreaChart.stories.tsx
@@ -42,6 +42,15 @@ DefaultResponsive.args = {
     dataKey: 'month',
 };
 
+export const WithStacked = ResponsiveTemplate.bind({});
+// More on args: https://storybook.js.org/docs/react/writing-stories/args
+WithStacked.args = {
+    data: data,
+    categories: [ 'Sales', 'Successfull Payments' ],
+    dataKey: 'month',
+    stack: true,
+};
+
 export const WithValueFormatter = ResponsiveTemplate.bind({});
 // More on args: https://storybook.js.org/docs/react/writing-stories/args
 WithValueFormatter.args = {
@@ -119,13 +128,4 @@ export const WithNoDataKey = DefaultTemplate.bind({});
 WithNoDataKey.args = {
     data: data,
     categories: [ 'Sales', 'Successfull Payments' ],
-};
-
-
-export const StackedResponsive = ResponsiveTemplate.bind({});
-// More on args: https://storybook.js.org/docs/react/writing-stories/args
-StackedResponsive.args = {
-    data: data,
-    categories: [ 'Sales', 'Successfull Payments' ],
-    stacked: true,
 };

--- a/src/stories/chart-elements/AreaChart.stories.tsx
+++ b/src/stories/chart-elements/AreaChart.stories.tsx
@@ -120,3 +120,12 @@ WithNoDataKey.args = {
     data: data,
     categories: [ 'Sales', 'Successfull Payments' ],
 };
+
+
+export const StackedResponsive = ResponsiveTemplate.bind({});
+// More on args: https://storybook.js.org/docs/react/writing-stories/args
+StackedResponsive.args = {
+    data: data,
+    categories: [ 'Sales', 'Successfull Payments' ],
+    stacked: true,
+};


### PR DESCRIPTION
Addresses part of #193 by adding an option prop for `stacked` to `BaseChartProps` and adds a `stackId` to the `Area element if `stacked` is set to true.

**Default Responsive**
<img width="282" alt="image" src="https://user-images.githubusercontent.com/13946/202866041-1887ab39-6639-4ddb-86d2-2992151c42f3.png">


Default Responsive with Stacked Option
<img width="271" alt="image" src="https://user-images.githubusercontent.com/13946/202866070-89d75546-7dbc-4c88-b07b-349a262592ca.png">

