### PR TITLE
feat: add show cutout prop

### DIFF
--- a/src/components/chart-elements/DonutChart/DonutChart.tsx
+++ b/src/components/chart-elements/DonutChart/DonutChart.tsx
@@ -21,10 +21,6 @@ import {
 import { parseData, parseLabelInput } from './inputParser';
 import { DonutChartTooltip } from './DonutChartTooltip';
 
-export interface DonutChartDataPoint {
-    color?: Color,
-}
-
 export interface DonutChartProps {
     data: any[],
     category?: string,

--- a/src/components/chart-elements/DonutChart/DonutChart.tsx
+++ b/src/components/chart-elements/DonutChart/DonutChart.tsx
@@ -35,6 +35,7 @@ export interface DonutChartProps {
     showLabel?: boolean,
     showAnimation?: boolean,
     showTooltip?: boolean,
+    showCutout?: boolean,
     height?: Height,
     marginTop?: MarginTop,
 }
@@ -49,6 +50,7 @@ const DonutChart = ({
     showLabel = true,
     showAnimation = true,
     showTooltip = true,
+    showCutout = true,
     height = 'h-44',
     marginTop = 'mt-0',
 }: DonutChartProps) => {
@@ -63,7 +65,7 @@ const DonutChart = ({
         >
             <ResponsiveContainer width="100%" height="100%">
                 <ReChartsDonutChart>
-                    { showLabel ? (
+                    { showLabel && showCutout ? (
                         <text
                             x="50%"
                             y="50%"
@@ -80,7 +82,7 @@ const DonutChart = ({
                         cy="50%"
                         startAngle={ 90 }
                         endAngle={ -270 }
-                        innerRadius="75%"
+                        innerRadius={ showCutout ? '75%' : '0%'} 
                         outerRadius="100%"
                         paddingAngle={ 0 }
                         dataKey={ category }

--- a/src/stories/chart-elements/DonutChart.stories.tsx
+++ b/src/stories/chart-elements/DonutChart.stories.tsx
@@ -140,6 +140,14 @@ WithLongValues.args = {
     dataKey: 'city',
 };
 
+export const WithNoCutout = DefaultTemplate.bind({});
+WithNoCutout.args = {
+    data: data,
+    category: 'sales',
+    dataKey: 'city',
+    showCutout: false
+};
+
 export const WithNoData = DefaultTemplate.bind({});
 // More on args: https://storybook.js.org/docs/react/writing-stories/args
 WithNoData.args = {


### PR DESCRIPTION
Addresses #198 by adding the `showCutout` prop to DonutChart. It is set to false by default, so it does not change existing behavior. Also, when it is set to false the label in the center won't be rendered.

I also added a story to showcase it:
<img width="198" alt="Screenshot 2022-11-23 at 13 54 43" src="https://user-images.githubusercontent.com/118190164/203552031-80f652e4-1e84-4ff7-8060-cbc1d7dfea79.png">
