### PR TITLE
feat: add href prop to BarList item

### DIFF
--- a/src/components/vis-elements/BarList/BarList.tsx
+++ b/src/components/vis-elements/BarList/BarList.tsx
@@ -19,6 +19,7 @@ type BarListData = {
     value: number,
     name: string,
     icon?: React.ElementType,
+    href?: string;
 }
 
 const getWidthsFromValues = (dataValues: number[]) => {
@@ -84,13 +85,27 @@ const BarList = ({
                                         getColorVariantsFromColorThemeValue(defaultColors.lightText).textColor,
                                     )} aria-hidden="true" />
                                 ) : null }
-                                <p className={ classNames(
-                                    'text-elem tr-whitespace-nowrap tr-truncate',
-                                    getColorVariantsFromColorThemeValue(defaultColors.darkText).textColor,
-                                    fontSize.sm,
-                                ) }>
-                                    { item.name }
-                                </p>
+                                { item.href ? (
+                                    <a
+                                        href={item.href}
+                                        target="_blank"
+                                        rel="noreferrer"
+                                        className={ classNames(
+                                            'text-elem tr-whitespace-nowrap tr-truncate tr-text-blue-500',
+                                            'tr-no-underline hover:tr-underline visited:tr-text-blue-500',
+                                            fontSize.sm,
+                                        ) }>
+                                        { item.name }
+                                    </a>
+                                ) : (
+                                    <p className={ classNames(
+                                        'text-elem tr-whitespace-nowrap tr-truncate',
+                                        getColorVariantsFromColorThemeValue(defaultColors.darkText).textColor,
+                                        fontSize.sm,
+                                    ) }>
+                                        { item.name }
+                                    </p>
+                                ) }
                             </div>
                         </div>
                     );

--- a/src/stories/vis-elements/BarList.stories.tsx
+++ b/src/stories/vis-elements/BarList.stories.tsx
@@ -45,3 +45,17 @@ WithIcon.args = {
     ],
     valueFormatter: (value) => `${value} USD`
 };
+
+export const WithLinks = Template.bind({});
+// More on args: https://storybook.js.org/docs/react/writing-stories/args
+WithLinks.args = {
+    data: [
+        { name: '/home', value: 100000000, href: 'https://www.tremor.so/' },
+        { name: '/imprint', value: 351 },
+        { name: '/cancellation', value: 271, href: 'https://www.tremor.so/' },
+        { name: `/special-offer-august-getsahdkjhagskdfjhgakshjgdfkjahsgdfjkgasdjkhfgajkshgdfjkhagsdkjhfgajhksdgfjkhasdg
+            fjkhagsdjhkgfasjkdgfjkasdhgkjgfdsk`, value: 191, href: 'https://www.tremor.so/' },
+        { name: '/documentation', value: 0 },
+    ],
+    valueFormatter: (value) => `${value} USD`
+};

--- a/src/stories/vis-elements/BarList.stories.tsx
+++ b/src/stories/vis-elements/BarList.stories.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 
-import { BarList, Card } from 'components';
+import { BarList, Block, Card } from 'components';
+import { BaseColors } from 'lib';
 import { CalendarIcon } from 'assets';
 
 // More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
@@ -16,6 +17,18 @@ const Template: ComponentStory<typeof BarList> = (args) => (
     <Card>
         <BarList {...args} />
     </Card>
+);
+
+const ColorsTemplate: ComponentStory<typeof BarList> = (args) => (
+    <Block spaceY="space-y-2">
+        {
+            Object.values(BaseColors).map((color) => (
+                <Card>
+                    <BarList {...args} color={ color } />
+                </Card>
+            ))
+        }
+    </Block>
 );
   
 export const Default = Template.bind({});
@@ -58,4 +71,18 @@ WithLinks.args = {
         { name: '/documentation', value: 0 },
     ],
     valueFormatter: (value) => `${value} USD`
+};
+
+export const Colors = ColorsTemplate.bind({});
+// More on args: https://storybook.js.org/docs/react/writing-stories/args
+Colors.args = {
+    data: [
+        { name: '/home', value: 100000000, href: 'https://www.tremor.so/' },
+        { name: '/imprint', value: 351 },
+        { name: '/cancellation', value: 271, href: 'https://www.tremor.so/' },
+        { name: `/special-offer-august-getsahdkjhagskdfjhgakshjgdfkjahsgdfjkgasdjkhfgajkshgdfjkhagsdkjhfgajhksdgfjkhasdg
+            fjkhagsdjhkgfasjkdgfjkasdhgkjgfdsk`, value: 191, href: 'https://www.tremor.so/' },
+        { name: '/documentation', value: 0 },
+    ],
+    valueFormatter: (value) => `${value} USD`,
 };


### PR DESCRIPTION
Addresses #203. This prop is optional. If passed the rendered element is `<a>` (with `target="_blank"` and `rel="noreferrer"`) instead of `<p>`.
Also adds a story showcasing it:
<img width="1475" alt="Screenshot 2022-11-25 at 13 26 21" src="https://user-images.githubusercontent.com/118190164/203985785-b652fcb7-4e8e-4621-a67d-8726313fd9cb.png">
