### PR TITLE
feat: Add dataKey and categories inference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 .DS_Store
+storybook-static

--- a/src/components/chart-elements/AreaChart/AreaChart.tsx
+++ b/src/components/chart-elements/AreaChart/AreaChart.tsx
@@ -17,6 +17,7 @@ import ChartTooltip from '../common/ChartTooltip';
 import { constructCategoryColors } from '../common/constructCategoryColors';
 
 import {
+    PickOfType,
     classNames,
     defaultValueFormatter,
     getColorTheme,
@@ -27,11 +28,11 @@ import {
     themeColorRange
 } from 'lib';
 
-export interface AreaChartProps extends BaseChartProps {
+export interface AreaChartProps<T> extends BaseChartProps<T> {
     stack?: boolean,
 }
 
-const AreaChart = ({
+const AreaChart = <T extends PickOfType<T, unknown>,>({
     data = [],
     categories = [],
     dataKey,
@@ -50,7 +51,7 @@ const AreaChart = ({
     showGradient = true,
     height = 'h-80',
     marginTop = 'mt-0',
-}: AreaChartProps) => {
+}: AreaChartProps<T>) => {
     const [legendHeight, setLegendHeight] = useState(60);
     const categoryColors = constructCategoryColors(categories, colors);
 

--- a/src/components/chart-elements/BarChart/BarChart.tsx
+++ b/src/components/chart-elements/BarChart/BarChart.tsx
@@ -17,6 +17,7 @@ import ChartTooltip from '../common/ChartTooltip';
 import { constructCategoryColors } from '../common/constructCategoryColors';
 
 import {
+    PickOfType,
     classNames,
     defaultValueFormatter,
     getColorTheme,
@@ -27,13 +28,13 @@ import {
     themeColorRange
 } from 'lib';
 
-export interface BarChartProps extends BaseChartProps {
+export interface BarChartProps<T> extends BaseChartProps<T> {
     layout?: 'vertical' | 'horizontal',
     stack?: boolean,
     relative?: boolean,
 }
 
-const BarChart = ({
+const BarChart = <T extends PickOfType<T, unknown>,>({
     data = [],
     categories = [],
     dataKey,
@@ -53,7 +54,7 @@ const BarChart = ({
     height = 'h-80',
     marginTop = 'mt-0',
     autoMinValue = false,
-}: BarChartProps) => {
+}: BarChartProps<T>) => {
     const [legendHeight, setLegendHeight] = useState(60);
     const categoryColors = constructCategoryColors(categories, colors);
 

--- a/src/components/chart-elements/DonutChart/DonutChart.tsx
+++ b/src/components/chart-elements/DonutChart/DonutChart.tsx
@@ -9,6 +9,8 @@ import {
 
 import { Color, Height, MarginTop, ValueFormatter } from '../../../lib/inputTypes';
 import {
+    PickKeyOfType,
+    PickOfType,
     classNames,
     defaultColors,
     defaultValueFormatter,
@@ -23,11 +25,11 @@ import { DonutChartTooltip } from './DonutChartTooltip';
 
 type DonutChartVariant = 'donut' | 'pie';
 
-export interface DonutChartProps {
-    data: any[],
-    category?: string,
-    dataKey?: string,
-    colors?: Color[],
+export interface DonutChartProps<T> {
+    data: T[],
+    category?: PickKeyOfType<T, number>,
+    dataKey?: PickKeyOfType<T, string>,
+    colors?: Color[]
     variant?: DonutChartVariant,
     valueFormatter?: ValueFormatter,
     label?: string,
@@ -38,10 +40,10 @@ export interface DonutChartProps {
     marginTop?: MarginTop,
 }
 
-const DonutChart = ({
+const DonutChart = <T extends PickOfType<T, unknown>,>({
     data = [],
-    category = 'value',
-    dataKey = 'name',
+    category = 'value' as PickKeyOfType<T, number>,
+    dataKey = 'name' as PickKeyOfType<T, string>,
     colors = themeColorRange,
     variant = 'donut',
     valueFormatter = defaultValueFormatter,
@@ -51,7 +53,7 @@ const DonutChart = ({
     showTooltip = true,
     height = 'h-44',
     marginTop = 'mt-0',
-}: DonutChartProps) => {
+}: DonutChartProps<T>) => {
     const isDonut = variant == 'donut';
 
     const parsedLabelInput = parseLabelInput(label, valueFormatter, data, category);

--- a/src/components/chart-elements/LineChart/LineChart.tsx
+++ b/src/components/chart-elements/LineChart/LineChart.tsx
@@ -16,7 +16,8 @@ import ChartLegend from 'components/chart-elements/common/ChartLegend';
 import ChartTooltip from '../common/ChartTooltip';
 import { constructCategoryColors } from '../common/constructCategoryColors';
 
-import {
+import {    
+    PickOfType,
     classNames,
     defaultValueFormatter,
     getColorTheme,
@@ -27,7 +28,7 @@ import {
     themeColorRange
 } from 'lib';
 
-const LineChart = ({
+const LineChart = <T extends PickOfType<T, unknown>,>({
     data = [],
     categories = [],
     dataKey,
@@ -44,7 +45,7 @@ const LineChart = ({
     height = 'h-80',
     marginTop = 'mt-0',
     autoMinValue = false,
-}: BaseChartProps) => {
+}: BaseChartProps<T>) => {
     const [legendHeight, setLegendHeight] = useState(60);
     const categoryColors = constructCategoryColors(categories, colors);
 

--- a/src/components/chart-elements/common/BaseChartProps.tsx
+++ b/src/components/chart-elements/common/BaseChartProps.tsx
@@ -2,14 +2,15 @@ import {
     Color,
     Height,
     MarginTop,
+    PickKeyOfType,
     ValueFormatter,
     Width,
 } from '../../../lib';
 
-interface BaseChartProps {
-    data: any[],
-    categories: string[],
-    dataKey: string,
+interface BaseChartProps<T> {
+    data: T[],
+    categories: (PickKeyOfType<T, number>)[],
+    dataKey: PickKeyOfType<T, string>,
     colors?: Color[],
     valueFormatter?: ValueFormatter,
     autoMinValue?: boolean,

--- a/src/components/vis-elements/BarList/BarList.tsx
+++ b/src/components/vis-elements/BarList/BarList.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 
 import {
-    BaseColors,
+    BaseColors,   
+    PickKeyOfType,
+    PickOfType,
     borderRadius,
     classNames,
     defaultColors,
@@ -15,10 +17,7 @@ import {
 } from 'lib';
 import { Color, MarginTop, ValueFormatter } from '../../../lib';
 
-type BarListData = {
-    key?: string,
-    value: number,
-    name: string,
+export interface BarListData {
     icon?: React.ElementType,
     href?: string;
 }
@@ -35,22 +34,26 @@ const getWidthsFromValues = (dataValues: number[]) => {
     });
 };
 
-export interface BarListProps {
-    data: BarListData[],
+export interface BarListProps<T extends BarListData> {
+    data: T[],
+    value?: PickKeyOfType<T, number>,
+    key?: PickKeyOfType<T, string>,
     valueFormatter?: ValueFormatter,
     color?: Color,
     showAnimation?: boolean,
     marginTop?: MarginTop,
 }
 
-const BarList = ({
+const BarList = <T extends PickOfType<T, unknown> & BarListData,>({
     data = [],
+    value = 'value' as PickKeyOfType<T, number>,
+    key = 'name' as PickKeyOfType<T, string>,
     color = BaseColors.Blue,
     valueFormatter = defaultValueFormatter,
     showAnimation = true,
     marginTop = 'mt-0',
-}: BarListProps) => {
-    const widths = getWidthsFromValues(data.map((item) => item.value));
+}: BarListProps<T>) => {
+    const widths = getWidthsFromValues(data.map((item) => item[value]));
 
     const rowHeight = sizing.threeXl.height;
 
@@ -66,7 +69,7 @@ const BarList = ({
 
                     return (
                         <div
-                            key={ item.key ?? item.name }
+                            key={ item[key] }
                             className={ classNames(
                                 'tr-flex tr-items-center',
                                 rowHeight,
@@ -96,7 +99,7 @@ const BarList = ({
                                             'tr-no-underline hover:tr-underline visited:tr-text-blue-500',
                                             fontSize.sm,
                                         ) }>
-                                        { item.name }
+                                        { item[key] }
                                     </a>
                                 ) : (
                                     <p className={ classNames(
@@ -104,7 +107,7 @@ const BarList = ({
                                         getColorVariantsFromColorThemeValue(defaultColors.darkText).textColor,
                                         fontSize.sm,
                                     ) }>
-                                        { item.name }
+                                        { item[key] }
                                     </p>
                                 ) }
                             </div>
@@ -115,7 +118,7 @@ const BarList = ({
             <div className="tr-text-right tr-min-w-min">
                 { data.map((item, idx) => (
                     <div
-                        key={ item.key ?? item.name }
+                        key={ item[key] }
                         className={ classNames(
                             'tr-flex tr-justify-end tr-items-center',
                             rowHeight,
@@ -127,7 +130,7 @@ const BarList = ({
                             getColorVariantsFromColorThemeValue(defaultColors.darkText).textColor,
                             fontSize.sm,
                         ) }>
-                            { valueFormatter(item.value) }
+                            { valueFormatter(item[value]) }
                         </p>
                     </div>
                 )) }

--- a/src/lib/utils.tsx
+++ b/src/lib/utils.tsx
@@ -132,3 +132,9 @@ export const useWindowSize = (handler: {(): void}, initialWindowSize?: number) =
         return () => window.removeEventListener('resize', handleResize);
     }, [windowSize]);
 };
+
+export type PickOfType<T, U> = {
+    [K in keyof T as T[K] extends U ? K : never]: T[K]
+}
+
+export type PickKeyOfType<T, U> = string & keyof PickOfType<T, U>;

--- a/src/stories/chart-elements/AreaChart.stories.tsx
+++ b/src/stories/chart-elements/AreaChart.stories.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 
-import { ComponentMeta, ComponentStory } from '@storybook/react';
+import { ComponentMeta, Story } from '@storybook/react';
 
 import { AreaChart, Card, Title } from 'components';
+import { AreaChartProps } from 'components/chart-elements/AreaChart/AreaChart';
+import { PickOfType } from 'lib';
 import { simpleBaseChartData as data } from './helpers/testData';
 import { valueFormatter } from './helpers/utils';
 
@@ -13,7 +15,9 @@ export default {
 } as ComponentMeta<typeof AreaChart>;
 // More on component templates: https://storybook.js.org/docs/react/writing-stories/introduction#using-args
 
-const ResponsiveTemplate: ComponentStory<typeof AreaChart> = (args) => (
+type DataEntry = typeof data[0]
+
+const ResponsiveTemplate = (<T extends PickOfType<T, unknown>,>(): Story<AreaChartProps<T>> => (args) => (
     <>
         <Title>Mobile</Title>
         <div className="tr-w-64">
@@ -26,13 +30,13 @@ const ResponsiveTemplate: ComponentStory<typeof AreaChart> = (args) => (
             <AreaChart { ...args } />
         </Card>
     </>
-);
+))<DataEntry>();
 
-const DefaultTemplate: ComponentStory<typeof AreaChart>= ({ ...args }) => (
+const DefaultTemplate = (<T extends PickOfType<T, unknown>,>(): Story<AreaChartProps<T>> => (args) => (
     <Card>
         <AreaChart { ...args } />
     </Card>
-);
+))<DataEntry>();
 
 export const DefaultResponsive = ResponsiveTemplate.bind({});
 // More on args: https://storybook.js.org/docs/react/writing-stories/args

--- a/src/stories/chart-elements/BarChart.stories.tsx
+++ b/src/stories/chart-elements/BarChart.stories.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 
-import { ComponentMeta, ComponentStory } from '@storybook/react';
+import { ComponentMeta, Story } from '@storybook/react';
 
 import { BarChart, Card, Title } from 'components';
+import { BarChartProps } from 'components/chart-elements/BarChart/BarChart';
+import { PickOfType } from 'lib';
 import { simpleBaseChartData as data } from './helpers/testData';
 import { valueFormatter } from 'stories/chart-elements/helpers/utils';
 
@@ -14,7 +16,9 @@ export default {
 } as ComponentMeta<typeof BarChart>;
 // More on component templates: https://storybook.js.org/docs/react/writing-stories/introduction#using-args
 
-const ResponsiveTemplate: ComponentStory<typeof BarChart> = (args) => (
+type DataEntry = typeof data[0]
+
+const ResponsiveTemplate = (<T extends PickOfType<T, unknown>,>(): Story<BarChartProps<T>> => (args) => (
     <>
         <Title>Mobile</Title>
         <div className="tr-w-64">
@@ -27,13 +31,13 @@ const ResponsiveTemplate: ComponentStory<typeof BarChart> = (args) => (
             <BarChart { ...args } />
         </Card>
     </>
-);
+))<DataEntry>();
 
-const DefaultTemplate: ComponentStory<typeof BarChart>= ({ ...args }) => (
+const DefaultTemplate = (<T extends PickOfType<T, unknown>,>(): Story<BarChartProps<T>> => (args) => (
     <Card>
         <BarChart { ...args } />
     </Card>
-);
+))<DataEntry>();
 
 export const DefaultResponsive = ResponsiveTemplate.bind({});
 // More on args: https://storybook.js.org/docs/react/writing-stories/args

--- a/src/stories/chart-elements/DonutChart.stories.tsx
+++ b/src/stories/chart-elements/DonutChart.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { ComponentMeta, ComponentStory } from '@storybook/react';
+import { ComponentMeta, Story } from '@storybook/react';
 
 import { 
     BadgeDelta,
@@ -11,7 +11,9 @@ import {
     ListItem,
     Title
 } from 'components';
-import { DeltaType } from 'lib';
+import { DonutChartProps } from 'components/chart-elements/DonutChart/DonutChart';
+
+import { DeltaType, PickOfType } from 'lib';
 
 import { simpleSingleCategoryData as data } from 'stories/chart-elements/helpers/testData';
 import { valueFormatter } from 'stories/chart-elements/helpers/utils';
@@ -23,7 +25,9 @@ export default {
 } as ComponentMeta<typeof DonutChart>;
 // More on component templates: https://storybook.js.org/docs/react/writing-stories/introduction#using-args
 
-const ResponsiveTemplate: ComponentStory<typeof DonutChart> = (args) => (
+type DataEntry = typeof data[0]
+
+const ResponsiveTemplate = (<T extends PickOfType<T, unknown>,>(): Story<DonutChartProps<T>> => (args) => (
     <>
         <Title>Mobile</Title>
         <div className="tr-w-64">
@@ -36,15 +40,15 @@ const ResponsiveTemplate: ComponentStory<typeof DonutChart> = (args) => (
             <DonutChart { ...args } />
         </Card>
     </>
-);
+))<DataEntry>();
 
-const DefaultTemplate: ComponentStory<typeof DonutChart>= ({ ...args }) => (
+const DefaultTemplate = (<T extends PickOfType<T, unknown>,>(): Story<DonutChartProps<T>> => (args) => (
     <Card>
         <DonutChart { ...args } />
     </Card>
-);
+))<DataEntry>();
 
-const BlockTemplate: ComponentStory<typeof DonutChart> = (args) => (
+const BlockTemplate  = (<T extends PickOfType<T, unknown>,>(): Story<DonutChartProps<T>> => (args) => (
     <>
         <Title>Base Layer (Beta)</Title>
         <div className="tr-w-full tr-mt-4">
@@ -71,7 +75,7 @@ const BlockTemplate: ComponentStory<typeof DonutChart> = (args) => (
             </Card>
         </div>
     </>
-);
+))<DataEntry>();
 
 export const DefaultResponsive = ResponsiveTemplate.bind({});
 // More on args: https://storybook.js.org/docs/react/writing-stories/args

--- a/src/stories/chart-elements/LineChart.stories.tsx
+++ b/src/stories/chart-elements/LineChart.stories.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 
-import { ComponentMeta, ComponentStory } from '@storybook/react';
+import { ComponentMeta, Story } from '@storybook/react';
 
 import { Card, LineChart, Title } from 'components';
+import { BarChartProps } from 'components/chart-elements/BarChart/BarChart';
+import { PickOfType } from 'lib';
 import { simpleBaseChartData as data } from './helpers/testData';
 import { valueFormatter } from 'stories/chart-elements/helpers/utils';
 
@@ -13,7 +15,9 @@ export default {
 } as ComponentMeta<typeof LineChart>;
 // More on component templates: https://storybook.js.org/docs/react/writing-stories/introduction#using-args
 
-const ResponsiveTemplate: ComponentStory<typeof LineChart> = (args) => (
+type DataEntry = typeof data[0]
+
+const ResponsiveTemplate = (<T extends PickOfType<T, unknown>,>(): Story<BarChartProps<T>> => (args) => (
     <>
         <Title>Mobile</Title>
         <div className="tr-w-64">
@@ -26,13 +30,13 @@ const ResponsiveTemplate: ComponentStory<typeof LineChart> = (args) => (
             <LineChart { ...args } />
         </Card>
     </>
-);
+))<DataEntry>();
 
-const DefaultTemplate: ComponentStory<typeof LineChart>= ({ ...args }) => (
+const DefaultTemplate = (<T extends PickOfType<T, unknown>,>(): Story<BarChartProps<T>> => (args) => (
     <Card>
         <LineChart { ...args } />
     </Card>
-);
+))<DataEntry>();
 
 export const DefaultResponsive = ResponsiveTemplate.bind({});
 // More on args: https://storybook.js.org/docs/react/writing-stories/args

--- a/src/stories/vis-elements/BarList.stories.tsx
+++ b/src/stories/vis-elements/BarList.stories.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 
-import { ComponentMeta, ComponentStory } from '@storybook/react';
+import { ComponentMeta, Story } from '@storybook/react';
 
 import { BarList, Block, Card } from 'components';
-import { BaseColors } from 'lib';
+import { BarListData, BarListProps } from 'components/vis-elements/BarList/BarList';
+import { BaseColors, PickOfType } from 'lib';
 import { CalendarIcon } from 'assets';
 
 // More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
@@ -13,13 +14,18 @@ export default {
 } as ComponentMeta<typeof BarList>;
 // More on component templates: https://storybook.js.org/docs/react/writing-stories/introduction#using-args
 
-const Template: ComponentStory<typeof BarList> = (args) => (
+type DataEntry = BarListData & {
+    name: string;
+    value: number;
+}
+
+const Template = (<T extends PickOfType<T, unknown> & BarListData,>(): Story<BarListProps<T>> => (args) => (
     <Card>
         <BarList {...args} />
     </Card>
-);
+))<DataEntry>();
 
-const ColorsTemplate: ComponentStory<typeof BarList> = (args) => (
+const ColorsTemplate = (<T extends PickOfType<T, unknown> & BarListData,>(): Story<BarListProps<T>> => (args) => (
     <Block spaceY="space-y-2">
         {
             Object.values(BaseColors).map((color) => (
@@ -29,7 +35,7 @@ const ColorsTemplate: ComponentStory<typeof BarList> = (args) => (
             ))
         }
     </Block>
-);
+))<DataEntry>();
   
 export const Default = Template.bind({});
 // More on args: https://storybook.js.org/docs/react/writing-stories/args


### PR DESCRIPTION
Addresses #238  by allowing only `string` values into **dataKey** prop and only `number` values in **categories** prop

A few considerations:

- **categories** prop allows duplicate entries (as it is right now)
- if the values in the data array are of different types, then only the intersection can be passed in **dataKey** or **categories**
- it can be also done with just `keyof T & string`, but it would require more casting inside of the component
- Same can be achieved if T would be hardtyped (as it is in **BarList** for example) with addition of some **labelFormatter**