### PR TITLE
Remove `console.log` from `getYAxisDomain` utility

### DIFF
--- a/src/components/chart-elements/common/utils.ts
+++ b/src/components/chart-elements/common/utils.ts
@@ -18,6 +18,5 @@ export const getYAxisDomain = (
 ) => {
     const minDomain = autoMinValue ? 'auto' : (minValue ?? 0);
     const maxDomain = maxValue ?? 'auto';
-    console.log([minDomain, maxDomain]);
     return [minDomain, maxDomain];
 };


### PR DESCRIPTION
Removes a console.log left in the `getYAxisDomain` utility.

<img width="234" alt="Screenshot 2022-12-13 at 4 48 20 PM" src="https://user-images.githubusercontent.com/11774595/207469835-ec711706-2f01-4cbd-bb5c-76509c74187c.png">
