### PR TITLE
feat: Added disabled cursor

### DIFF
--- a/src/components/input-elements/Tab/Tab.tsx
+++ b/src/components/input-elements/Tab/Tab.tsx
@@ -68,7 +68,7 @@ const Tab = ({
                         'tr-flex-none',
                         sizing.lg.height,
                         sizing.lg.width,
-                        spacing.lg.marginRight,
+                        spacing.sm.marginRight,
                         privateProps?.isActive
                             ? getColorVariantsFromColorThemeValue(getColorTheme(privateProps!.color).text)
                                 .textColor

--- a/src/tremor.css
+++ b/src/tremor.css
@@ -13,6 +13,7 @@ html {
 
 button {
     background-color: transparent;
+    appearance: button;
     -webkit-appearance: button;
 }
 
@@ -163,6 +164,7 @@ Correct the cursor style of increment and decrement buttons in Safari.
 
 .tremor-base [type='search'],
 [type='search'].tremor-base {
+    appearance: textfield;
     -webkit-appearance: textfield; /* 1 */
     outline-offset: -2px; /* 2 */
 }

--- a/src/tremor.css
+++ b/src/tremor.css
@@ -225,7 +225,7 @@ button.tremor-base,
 
 .tremor-base :disabled,
 :disabled.tremor-base {
-    cursor: default;
+    cursor: not-allowed;
 }
 
 /*


### PR DESCRIPTION
**CSS**
* Changed CSS Styling for the cursor when hovered over `disabled` elements
* Affects `TextInput`, `Button`, and `ButtonInline`
* Resolved compatibility issues with `-webkit-*` classes by adding the corresponding base styles
* Solves #245 by reducing the margin-right of the icon from lg to sm