### PR TITLE
feat: Enable passing a ref to TableCell

### DIFF
--- a/src/components/list-elements/Table/TableCell.tsx
+++ b/src/components/list-elements/Table/TableCell.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { forwardRef } from "react";
 
 import { TextAlignments, classNames, parseTextAlignment, spacing } from "lib";
 import { TextAlignment } from "../../../lib/inputTypes";
@@ -8,26 +8,26 @@ export interface TableCellProps {
   children: React.ReactNode;
 }
 
-const TableCell = ({
-  textAlignment = TextAlignments.Left,
-  children,
-}: TableCellProps) => {
-  return (
-    <>
-      <td
-        className={classNames(
-          "tr-align-middle tr-whitespace-nowrap tr-tabular-nums",
-          parseTextAlignment(textAlignment),
-          spacing.twoXl.paddingLeft,
-          spacing.twoXl.paddingRight,
-          spacing.twoXl.paddingTop,
-          spacing.twoXl.paddingBottom
-        )}
-      >
-        {children}
-      </td>
-    </>
-  );
-};
+const TableCell = forwardRef<HTMLTableCellElement, TableCellProps>(
+  ({ textAlignment = TextAlignments.Left, children }, ref) => {
+    return (
+      <>
+        <td
+          className={classNames(
+            "tr-align-middle tr-whitespace-nowrap tr-tabular-nums",
+            parseTextAlignment(textAlignment),
+            spacing.twoXl.paddingLeft,
+            spacing.twoXl.paddingRight,
+            spacing.twoXl.paddingTop,
+            spacing.twoXl.paddingBottom
+          )}
+          ref={ref}
+        >
+          {children}
+        </td>
+      </>
+    );
+  }
+);
 
 export default TableCell;


### PR DESCRIPTION
In order to a position a popover (using [Floating UI](https://floating-ui.com/)) next to a table cell in a Tremor table, I needed to access the `td` element that is rendered by `TableCell`.

This PR adds `forwardRef` to `TableCell` so that it's possible to pass a ref to it, for example:
```ts
function Demo() {
  const cellRef = useRef(null);

  useEffect(() => {
    if (cellRef.current) {
      // anchor popover to cellRef.current
    }
  }, []);

  return (
    <>
      <TableCell ref={cellRef}>Peter Doe</TableCell>
      <TableCell>1.000.000</TableCell>
      <TableCell>Region A</TableCell>
     </>
  );
}
```