### PR TITLE
feat: Add i18n Support to DateRangepicker

### DIFF
--- a/src/components/input-elements/Datepicker/Calendar.tsx
+++ b/src/components/input-elements/Datepicker/Calendar.tsx
@@ -12,7 +12,6 @@ import {
   previousSunday,
   startOfMonth,
 } from "date-fns";
-import { enUS } from "date-fns/locale";
 import { BaseColorContext } from "contexts";
 
 import {
@@ -34,14 +33,7 @@ import {
   sizing,
   spacing,
 } from "lib";
-import { getDateStyles } from "./dateRangePickerUtils";
-
-export type CalendarLocale = {
-  weekDays?: typeof WEEKDAYS;
-  locale?: typeof enUS;
-};
-
-const WEEKDAYS = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"];
+import { capitalize, getDateStyles, getWeekdays } from "./dateRangePickerUtils";
 
 export const colStartClasses = [
   "",
@@ -57,7 +49,7 @@ interface CalendarHeaderProps {
   enableYearPagination: boolean;
   anchorDate: Date;
   setAnchorDate: Dispatch<SetStateAction<Date>>;
-  locale?: CalendarLocale["locale"];
+  locale: Locale;
 }
 
 const CalendarHeader = ({
@@ -85,7 +77,10 @@ const CalendarHeader = ({
     }
   };
 
-  const displayedTitle = format(anchorDate, "MMMM yyyy", { locale });
+  const displayedTitle = capitalize(
+    format(anchorDate, "MMMM yyyy", { locale }),
+    locale
+  );
 
   return (
     <div
@@ -256,8 +251,7 @@ interface CalendarBodyProps {
   onDateClick: (date: Date) => void;
   minDate: Date | null;
   maxDate: Date | null;
-  weekDays?: CalendarLocale["weekDays"];
-  locale?: CalendarLocale["locale"];
+  locale: Locale;
 }
 
 const CalendarBody = ({
@@ -267,7 +261,6 @@ const CalendarBody = ({
   onDateClick,
   minDate,
   maxDate,
-  weekDays = WEEKDAYS,
   locale,
 }: CalendarBodyProps) => {
   const [hoveredDate, setHoveredDate] = useState<Date | undefined>();
@@ -275,6 +268,10 @@ const CalendarBody = ({
 
   const firstDayOfDisplayedMonth = startOfMonth(anchorDate);
   const lastDayOfDisplayedMonth = endOfMonth(anchorDate);
+
+  const weekdays = getWeekdays(locale).map((dayName) =>
+    capitalize(dayName, locale)
+  );
 
   const displayedDates = eachDayOfInterval({
     start: isSunday(firstDayOfDisplayedMonth)
@@ -312,7 +309,7 @@ const CalendarBody = ({
           fontWeight.md
         )}
       >
-        {weekDays.map((dayName) => (
+        {weekdays.map((dayName) => (
           <div key={dayName} className="tr-w-full tr-flex tr-justify-center">
             <div
               className={classNames(
@@ -381,7 +378,7 @@ export interface CalendarProps {
   minDate: Date | null;
   maxDate: Date | null;
   onDateClick: (date: Date) => void;
-  locales?: CalendarLocale;
+  locale: Locale;
 }
 
 const Calendar = ({
@@ -393,7 +390,7 @@ const Calendar = ({
   minDate,
   maxDate,
   onDateClick,
-  locales,
+  locale,
 }: CalendarProps) => {
   return (
     <div
@@ -408,7 +405,7 @@ const Calendar = ({
         enableYearPagination={enableYearPagination}
         anchorDate={anchorDate}
         setAnchorDate={setAnchorDate}
-        locale={locales?.locale}
+        locale={locale}
       />
       <CalendarBody
         anchorDate={anchorDate}
@@ -417,8 +414,7 @@ const Calendar = ({
         onDateClick={onDateClick}
         minDate={minDate}
         maxDate={maxDate}
-        locale={locales?.locale}
-        weekDays={locales?.weekDays}
+        locale={locale}
       />
     </div>
   );

--- a/src/components/input-elements/Datepicker/Calendar.tsx
+++ b/src/components/input-elements/Datepicker/Calendar.tsx
@@ -12,7 +12,7 @@ import {
   previousSunday,
   startOfMonth,
 } from "date-fns";
-
+import { enUS } from "date-fns/locale";
 import { BaseColorContext } from "contexts";
 
 import {
@@ -36,6 +36,11 @@ import {
 } from "lib";
 import { getDateStyles } from "./dateRangePickerUtils";
 
+export type CalendarLocale = {
+  weekDays?: typeof WEEKDAYS;
+  locale?: typeof enUS;
+};
+
 const WEEKDAYS = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"];
 
 export const colStartClasses = [
@@ -52,12 +57,14 @@ interface CalendarHeaderProps {
   enableYearPagination: boolean;
   anchorDate: Date;
   setAnchorDate: Dispatch<SetStateAction<Date>>;
+  locale?: CalendarLocale["locale"];
 }
 
 const CalendarHeader = ({
   enableYearPagination,
   anchorDate,
   setAnchorDate,
+  locale,
 }: CalendarHeaderProps) => {
   const handlePaginationClick = (
     type: "nextMonth" | "prevMonth" | "nextYear" | "prevYear"
@@ -78,7 +85,7 @@ const CalendarHeader = ({
     }
   };
 
-  const displayedTitle = format(anchorDate, "MMMM yyyy");
+  const displayedTitle = format(anchorDate, "MMMM yyyy", { locale });
 
   return (
     <div
@@ -249,6 +256,8 @@ interface CalendarBodyProps {
   onDateClick: (date: Date) => void;
   minDate: Date | null;
   maxDate: Date | null;
+  weekDays?: CalendarLocale["weekDays"];
+  locale?: CalendarLocale["locale"];
 }
 
 const CalendarBody = ({
@@ -258,6 +267,8 @@ const CalendarBody = ({
   onDateClick,
   minDate,
   maxDate,
+  weekDays = WEEKDAYS,
+  locale,
 }: CalendarBodyProps) => {
   const [hoveredDate, setHoveredDate] = useState<Date | undefined>();
   const color = useContext(BaseColorContext);
@@ -301,7 +312,7 @@ const CalendarBody = ({
           fontWeight.md
         )}
       >
-        {WEEKDAYS.map((dayName) => (
+        {weekDays.map((dayName) => (
           <div key={dayName} className="tr-w-full tr-flex tr-justify-center">
             <div
               className={classNames(
@@ -349,8 +360,8 @@ const CalendarBody = ({
                 )}
                 disabled={isCurrentDateDisabled}
               >
-                <time dateTime={format(date, "yyyy-MM-dd")}>
-                  {format(date, "d")}
+                <time dateTime={format(date, "yyyy-MM-dd", { locale })}>
+                  {format(date, "d", { locale })}
                 </time>
               </button>
             </div>
@@ -370,6 +381,7 @@ export interface CalendarProps {
   minDate: Date | null;
   maxDate: Date | null;
   onDateClick: (date: Date) => void;
+  locales?: CalendarLocale;
 }
 
 const Calendar = ({
@@ -381,6 +393,7 @@ const Calendar = ({
   minDate,
   maxDate,
   onDateClick,
+  locales,
 }: CalendarProps) => {
   return (
     <div
@@ -395,6 +408,7 @@ const Calendar = ({
         enableYearPagination={enableYearPagination}
         anchorDate={anchorDate}
         setAnchorDate={setAnchorDate}
+        locale={locales?.locale}
       />
       <CalendarBody
         anchorDate={anchorDate}
@@ -403,6 +417,8 @@ const Calendar = ({
         onDateClick={onDateClick}
         minDate={minDate}
         maxDate={maxDate}
+        locale={locales?.locale}
+        weekDays={locales?.weekDays}
       />
     </div>
   );

--- a/src/components/input-elements/Datepicker/DateRangePicker.tsx
+++ b/src/components/input-elements/Datepicker/DateRangePicker.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from "react";
 
 import { startOfDay, startOfToday } from "date-fns";
+import { enUS } from "date-fns/locale";
 
 import {
   BaseColorContext,
@@ -22,7 +23,8 @@ import Calendar from "./Calendar";
 import DateRangePickerButton from "./DateRangePickerButton";
 import { DropdownItem } from "components/input-elements/Dropdown";
 import Modal from "components/layout-elements/Modal";
-import { CalendarLocale } from "./Calendar";
+
+export type Locale = typeof enUS;
 
 export type DateRangePickerValue = [
   (Date | null)?,
@@ -33,6 +35,7 @@ export type DateRangePickerOption = {
   value: string;
   text: string;
   startDate: Date;
+  endDate?: Date;
 };
 
 export interface DateRangePickerProps {
@@ -44,11 +47,12 @@ export interface DateRangePickerProps {
   minDate?: Date | null;
   maxDate?: Date | null;
   placeholder?: string;
+  dropdownPlaceholder?: string;
   enableYearPagination?: boolean;
   color?: Color;
   marginTop?: MarginTop;
   maxWidth?: MaxWidth;
-  locales?: CalendarLocale & { pickerPlaceholder?: string };
+  locale?: Locale;
 }
 
 const DateRangePicker = ({
@@ -60,11 +64,12 @@ const DateRangePicker = ({
   minDate = null,
   maxDate = null,
   placeholder = "Select...",
+  dropdownPlaceholder = "Select...",
   color = BaseColors.Blue,
   marginTop = "mt-0",
   maxWidth = "max-w-none",
   enableYearPagination = false,
-  locales,
+  locale = enUS,
 }: DateRangePickerProps) => {
   const TODAY = startOfToday();
   const calendarRef = useRef(null);
@@ -168,8 +173,8 @@ const DateRangePicker = ({
           showDropdown={showDropdown}
           setShowDropdown={setShowDropdown}
           onDropdownKeyDown={handleDropdownKeyDown}
-          locale={locales?.locale}
-          pickerPlaceholder={locales?.pickerPlaceholder}
+          locale={locale}
+          dropdownPlaceholder={dropdownPlaceholder}
         />
         {/* Calendar Modal */}
         <Modal
@@ -188,7 +193,7 @@ const DateRangePicker = ({
             minDate={minDate}
             maxDate={maxDate}
             onDateClick={handleDateClick}
-            locales={locales}
+            locale={locale}
           />
         </Modal>
         {/* Dropdpown Modal */}

--- a/src/components/input-elements/Datepicker/DateRangePicker.tsx
+++ b/src/components/input-elements/Datepicker/DateRangePicker.tsx
@@ -22,6 +22,7 @@ import Calendar from "./Calendar";
 import DateRangePickerButton from "./DateRangePickerButton";
 import { DropdownItem } from "components/input-elements/Dropdown";
 import Modal from "components/layout-elements/Modal";
+import { CalendarLocale } from "./Calendar";
 
 export type DateRangePickerValue = [
   (Date | null)?,
@@ -47,6 +48,7 @@ export interface DateRangePickerProps {
   color?: Color;
   marginTop?: MarginTop;
   maxWidth?: MaxWidth;
+  locales?: CalendarLocale & { pickerPlaceholder?: string };
 }
 
 const DateRangePicker = ({
@@ -62,6 +64,7 @@ const DateRangePicker = ({
   marginTop = "mt-0",
   maxWidth = "max-w-none",
   enableYearPagination = false,
+  locales,
 }: DateRangePickerProps) => {
   const TODAY = startOfToday();
   const calendarRef = useRef(null);
@@ -165,6 +168,8 @@ const DateRangePicker = ({
           showDropdown={showDropdown}
           setShowDropdown={setShowDropdown}
           onDropdownKeyDown={handleDropdownKeyDown}
+          locale={locales?.locale}
+          pickerPlaceholder={locales?.pickerPlaceholder}
         />
         {/* Calendar Modal */}
         <Modal
@@ -183,6 +188,7 @@ const DateRangePicker = ({
             minDate={minDate}
             maxDate={maxDate}
             onDateClick={handleDateClick}
+            locales={locales}
           />
         </Modal>
         {/* Dropdpown Modal */}

--- a/src/components/input-elements/Datepicker/DateRangePickerButton.tsx
+++ b/src/components/input-elements/Datepicker/DateRangePickerButton.tsx
@@ -18,8 +18,14 @@ import {
 } from "lib";
 
 import { DateRangePickerOption, DateRangePickerValue } from "./DateRangePicker";
+import { CalendarLocale } from "./Calendar";
 
-const formatSelectedDates = (startDate: Date | null, endDate: Date | null) => {
+const formatSelectedDates = (
+  startDate: Date | null,
+  endDate: Date | null,
+  locale?: CalendarLocale["locale"]
+) => {
+  const localeCode = locale?.code || "en-US";
   if (!startDate && !endDate) {
     return "";
   } else if (startDate && !endDate) {
@@ -28,7 +34,7 @@ const formatSelectedDates = (startDate: Date | null, endDate: Date | null) => {
       month: "short",
       day: "numeric",
     };
-    return startDate.toLocaleDateString("en-US", options);
+    return startDate.toLocaleDateString(localeCode, options);
   } else if (startDate && endDate) {
     if (isEqual(startDate, endDate)) {
       const options: Intl.DateTimeFormatOptions = {
@@ -36,7 +42,7 @@ const formatSelectedDates = (startDate: Date | null, endDate: Date | null) => {
         month: "short",
         day: "numeric",
       };
-      return startDate.toLocaleDateString("en-US", options);
+      return startDate.toLocaleDateString(localeCode, options);
     } else if (
       startDate.getMonth() === endDate.getMonth() &&
       startDate.getFullYear() === endDate.getFullYear()
@@ -45,7 +51,7 @@ const formatSelectedDates = (startDate: Date | null, endDate: Date | null) => {
         month: "short",
         day: "numeric",
       };
-      return `${startDate.toLocaleDateString("en-US", optionsStartDate)} - 
+      return `${startDate.toLocaleDateString(localeCode, optionsStartDate)} - 
                     ${endDate.getDate()}, ${endDate.getFullYear()}`;
     } else {
       const options: Intl.DateTimeFormatOptions = {
@@ -53,8 +59,8 @@ const formatSelectedDates = (startDate: Date | null, endDate: Date | null) => {
         month: "short",
         day: "numeric",
       };
-      return `${startDate.toLocaleDateString("en-US", options)} - 
-                    ${endDate.toLocaleDateString("en-US", options)}`;
+      return `${startDate.toLocaleDateString(localeCode, options)} - 
+                    ${endDate.toLocaleDateString(localeCode, options)}`;
     }
   }
   return "";
@@ -73,6 +79,8 @@ interface DateRangePickerButtonProps {
   showDropdown: boolean;
   setShowDropdown: Dispatch<SetStateAction<boolean>>;
   onDropdownKeyDown: (e: React.KeyboardEvent<HTMLButtonElement>) => void;
+  locale?: CalendarLocale["locale"];
+  pickerPlaceholder?: string;
 }
 
 const DateRangePickerButton = ({
@@ -88,15 +96,17 @@ const DateRangePickerButton = ({
   showDropdown,
   setShowDropdown,
   onDropdownKeyDown,
+  locale,
+  pickerPlaceholder = "Select",
 }: DateRangePickerButtonProps) => {
   const [startDate, endDate, dropdownValue] = value;
   const hasSelection = (startDate || endDate) !== null;
   const calendarText = hasSelection
-    ? formatSelectedDates(startDate as Date, endDate as Date)
+    ? formatSelectedDates(startDate as Date, endDate as Date, locale)
     : placeholder;
   const dropdownText = dropdownValue
     ? String(options.find((option) => option.value === dropdownValue)?.text)
-    : "Select";
+    : pickerPlaceholder;
 
   return (
     <div

--- a/src/components/input-elements/Datepicker/DateRangePickerButton.tsx
+++ b/src/components/input-elements/Datepicker/DateRangePickerButton.tsx
@@ -18,12 +18,11 @@ import {
 } from "lib";
 
 import { DateRangePickerOption, DateRangePickerValue } from "./DateRangePicker";
-import { CalendarLocale } from "./Calendar";
 
 const formatSelectedDates = (
   startDate: Date | null,
   endDate: Date | null,
-  locale?: CalendarLocale["locale"]
+  locale?: Locale
 ) => {
   const localeCode = locale?.code || "en-US";
   if (!startDate && !endDate) {
@@ -79,8 +78,8 @@ interface DateRangePickerButtonProps {
   showDropdown: boolean;
   setShowDropdown: Dispatch<SetStateAction<boolean>>;
   onDropdownKeyDown: (e: React.KeyboardEvent<HTMLButtonElement>) => void;
-  locale?: CalendarLocale["locale"];
-  pickerPlaceholder?: string;
+  locale?: Locale;
+  dropdownPlaceholder?: string;
 }
 
 const DateRangePickerButton = ({
@@ -97,7 +96,7 @@ const DateRangePickerButton = ({
   setShowDropdown,
   onDropdownKeyDown,
   locale,
-  pickerPlaceholder = "Select",
+  dropdownPlaceholder = "Select",
 }: DateRangePickerButtonProps) => {
   const [startDate, endDate, dropdownValue] = value;
   const hasSelection = (startDate || endDate) !== null;
@@ -106,7 +105,7 @@ const DateRangePickerButton = ({
     : placeholder;
   const dropdownText = dropdownValue
     ? String(options.find((option) => option.value === dropdownValue)?.text)
-    : pickerPlaceholder;
+    : dropdownPlaceholder;
 
   return (
     <div

--- a/src/components/input-elements/Datepicker/dateRangePickerUtils.tsx
+++ b/src/components/input-elements/Datepicker/dateRangePickerUtils.tsx
@@ -5,17 +5,31 @@ import {
   getDayTextClassNames,
 } from "./datepickerUtils";
 import {
+  addDays,
+  format,
   max,
   min,
   startOfDay,
   startOfMonth,
   startOfToday,
+  startOfWeek,
   startOfYear,
   sub,
 } from "date-fns";
 import { Color } from "../../../lib/inputTypes";
 import { DateRangePickerOption } from "./DateRangePicker";
 import { classNames } from "lib";
+
+export const getWeekdays = (locale: Locale) => {
+  const firstDayOfWeek = startOfWeek(new Date());
+  return Array.from(Array(7)).map((e, i) =>
+    format(addDays(firstDayOfWeek, i), "EEEEEE", { locale })
+  );
+};
+
+export const capitalize = (s: string, locale: Locale) => {
+  return s.charAt(0).toLocaleUpperCase(locale.code) + s.substring(1);
+};
 
 export const getStartDate = (
   startDate: Date | null | undefined,

--- a/src/stories/input-elements/DateRangePicker.stories.tsx
+++ b/src/stories/input-elements/DateRangePicker.stories.tsx
@@ -105,11 +105,8 @@ UncontrolledWithDefaultDateRange.args = {
 export const UncontrolledWithDefaultFrLocale = UncontrolledTemplate.bind({});
 UncontrolledWithDefaultFrLocale.args = {
   // defaultValue: [new Date(2022, 10, 1), new Date()],
-  locales: {
-    locale: fr,
-    weekDays: ["Dim", "Lun", "Mar", "Mer", "Jeu", "Ven", "Sam"],
-    pickerPlaceholder: "Sélectionnez",
-  },
+  dropdownPlaceholder: "Sélectionnez",
+  locale: fr,
   placeholder: "Sélectionnez...",
 };
 

--- a/src/stories/input-elements/DateRangePicker.stories.tsx
+++ b/src/stories/input-elements/DateRangePicker.stories.tsx
@@ -11,7 +11,7 @@ import {
   Title,
 } from "components";
 import { dateRangePickerData } from "stories/input-elements/helpers/testData";
-
+import { fr } from "date-fns/locale";
 // More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 export default {
   title: "Tremor/InputElements/DateRangePicker",
@@ -101,6 +101,16 @@ export const UncontrolledDefault = UncontrolledTemplate.bind({});
 export const UncontrolledWithDefaultDateRange = UncontrolledTemplate.bind({});
 UncontrolledWithDefaultDateRange.args = {
   defaultValue: [new Date(2022, 10, 1), new Date()],
+};
+export const UncontrolledWithDefaultFrLocale = UncontrolledTemplate.bind({});
+UncontrolledWithDefaultFrLocale.args = {
+  // defaultValue: [new Date(2022, 10, 1), new Date()],
+  locales: {
+    locale: fr,
+    weekDays: ["Dim", "Lun", "Mar", "Mer", "Jeu", "Ven", "Sam"],
+    pickerPlaceholder: "Sélectionnez",
+  },
+  placeholder: "Sélectionnez...",
 };
 
 export const UncontrolledWithDefaultSelectOption = UncontrolledTemplate.bind(


### PR DESCRIPTION
### What

This pull request adds internationalization (i18n) support to the daterangepicker, allowing users to display date and time in their preferred language.

### Why

Internationalization is important for making the daterangepicker accessible to a wider audience and to provide a more personalized user experience. 

### Changes Made

* Added a new options `weekDays`, `locale (from date-fns/locale)`, `pickerPlaceholder` to the daterangepicker and calendar,
*  Update story book with `FR language`
```jsx
import { fr } from "date-fns/locale";


export const UncontrolledWithDefaultFrLocale = UncontrolledTemplate.bind({});
UncontrolledWithDefaultFrLocale.args = {
  locales: {
    locale: fr,
    weekDays: ["Dim", "Lun", "Mar", "Mer", "Jeu", "Ven", "Sam"],
    pickerPlaceholder: "Sélectionnez",
  },
  placeholder: "Sélectionnez...",
};
``` 

### Closes

Closes issue #270  