### PR TITLE
fix: Remove a recharts-sector outline

### DIFF
--- a/src/components/input-elements/Datepicker/DateRangePickerButton.tsx
+++ b/src/components/input-elements/Datepicker/DateRangePickerButton.tsx
@@ -124,7 +124,7 @@ const DateRangePickerButton = ({
         onKeyDown={onCalendarKeyDown}
         className={classNames(
           `input-elem tr-flex tr-items-center tr-w-full tr-truncate focus:tr-ring-0
-                     focus:tr-outline-0`,
+                     focus:tr-outline-none`,
           enableDropdown
             ? border.none.right
             : classNames(borderRadius.md.right, border.sm.right),
@@ -173,7 +173,7 @@ const DateRangePickerButton = ({
           onClick={() => setShowDropdown(!showDropdown)}
           className={classNames(
             "input-elem tr-inline-flex tr-justify-between tr-w-48 tr-truncate",
-            "focus:tr-ring-0 focus:tr-outline-0",
+            "focus:tr-ring-0 focus:tr-outline-none",
             getColorVariantsFromColorThemeValue(defaultColors.canvasBackground)
               .hoverBgColor,
             getColorVariantsFromColorThemeValue(defaultColors.border)

--- a/src/components/input-elements/Datepicker/Datepicker.tsx
+++ b/src/components/input-elements/Datepicker/Datepicker.tsx
@@ -109,7 +109,7 @@ const DatepickerButton = ({
       ref={datePickerRef}
       onClick={() => setShowDatePickerModal(!showDatePickerModal)}
       className={classNames(
-        "input-elem tr-flex tr-items-center tr-w-full tr-truncate focus:tr-ring-0 focus:tr-outline-0",
+        "input-elem tr-flex tr-items-center tr-w-full tr-truncate focus:tr-ring-0 focus:tr-outline-none",
         enableRelativeDates
           ? border.none.right
           : classNames(borderRadius.md.right, border.sm.right),
@@ -157,7 +157,7 @@ const DatepickerButton = ({
         onClick={() => setShowDropdownModal(!showDropdownModal)}
         className={classNames(
           "input-elem tr-inline-flex tr-justify-between tr-w-48 tr-truncate",
-          "focus:tr-ring-0 focus:tr-outline-0",
+          "focus:tr-ring-0 focus:tr-outline-none",
           getColorVariantsFromColorThemeValue(defaultColors.canvasBackground)
             .hoverBgColor,
           getColorVariantsFromColorThemeValue(defaultColors.border).borderColor,

--- a/src/components/input-elements/Dropdown/Dropdown.tsx
+++ b/src/components/input-elements/Dropdown/Dropdown.tsx
@@ -105,7 +105,7 @@ const Dropdown = <T,>({
         type="button"
         className={classNames(
           "input-elem tr-flex tr-justify-between tr-items-center tr-w-full",
-          "focus:tr-outline-0 focus:tr-ring-0",
+          "focus:tr-outline-none focus:tr-ring-0",
           Icon ? spacing.xl.paddingLeft : spacing.twoXl.paddingLeft,
           spacing.twoXl.paddingRight,
           spacing.sm.paddingTop,

--- a/src/components/input-elements/MultiSelectBox/MultiSelectBox.tsx
+++ b/src/components/input-elements/MultiSelectBox/MultiSelectBox.tsx
@@ -142,7 +142,7 @@ const MultiSelectBox = <T,>({
         type="button"
         className={classNames(
           "input-elem tr-flex tr-justify-between tr-items-center tr-w-full",
-          "focus:tr-ring-0 focus:tr-outline-0",
+          "focus:tr-ring-0 focus:tr-outline-none",
           Icon ? spacing.xl.paddingLeft : spacing.twoXl.paddingLeft,
           spacing.twoXl.paddingRight,
           spacing.sm.paddingTop,

--- a/src/components/input-elements/SelectBox/SelectBox.tsx
+++ b/src/components/input-elements/SelectBox/SelectBox.tsx
@@ -159,7 +159,7 @@ const SelectBox = <T,>({
           ref={inputRef}
           type="text"
           className={classNames(
-            "input-elem tr-w-full focus:tr-outline-0 focus:tr-ring-0 tr-bg-inherit",
+            "input-elem tr-w-full focus:tr-outline-none focus:tr-ring-0 tr-bg-inherit",
             getColorVariantsFromColorThemeValue(defaultColors.darkText)
               .textColor,
             Icon ? spacing.lg.paddingLeft : spacing.twoXl.paddingLeft,

--- a/src/components/input-elements/Tab/Tab.tsx
+++ b/src/components/input-elements/Tab/Tab.tsx
@@ -47,7 +47,7 @@ const Tab = ({ value, text, icon }: TabProps) => {
         type="button"
         className={classNames(
           "input-elem tr-flex tr-whitespace-nowrap tr-max-w-xs tr-truncate",
-          "focus:tr-outline-0 focus:tr-ring-0",
+          "focus:tr-outline-none focus:tr-ring-0",
           spacing.twoXs.paddingRight,
           spacing.twoXs.paddingLeft,
           spacing.sm.paddingTop,

--- a/src/components/input-elements/TextInput/TextInput.tsx
+++ b/src/components/input-elements/TextInput/TextInput.tsx
@@ -105,7 +105,7 @@ const TextInput = ({
         type="text"
         className={classNames(
           "tremor-base input-elem",
-          "tr-w-full focus:tr-outline-0 focus:tr-ring-0 tr-bg-inherit",
+          "tr-w-full focus:tr-outline-none focus:tr-ring-0 tr-bg-inherit",
           textColor,
           Icon ? spacing.lg.paddingLeft : spacing.twoXl.paddingLeft,
           error ? spacing.lg.paddingRight : spacing.twoXl.paddingRight,

--- a/src/tremor.css
+++ b/src/tremor.css
@@ -248,6 +248,13 @@ Ensure the default browser behavior of the `hidden` attribute.
   display: none;
 }
 
+/*
+  Remove outline when focus rechart sector
+*/
+.recharts-sector:focus {
+  outline: none;
+}
+
 *,
 ::before,
 ::after {


### PR DESCRIPTION
Showing focus outline when clicked a part of pie chart sector, add a line in tremor css.

Close #299 
Close #304 