### PR TITLE
test: Removed unsupported prop from Badge.test.tsx

### DIFF
--- a/src/tests/icon-elements/Badge.test.tsx
+++ b/src/tests/icon-elements/Badge.test.tsx
@@ -6,6 +6,8 @@ import Badge from "components/icon-elements/Badge";
 
 describe("Badge", () => {
   test("renders the Badge component with default props", () => {
-    render(<Badge text={"Badge"} />);
+    render(
+      <Badge>Badge</Badge>
+    );
   });
 });

--- a/src/tests/icon-elements/Badge.test.tsx
+++ b/src/tests/icon-elements/Badge.test.tsx
@@ -6,8 +6,6 @@ import Badge from "components/icon-elements/Badge";
 
 describe("Badge", () => {
   test("renders the Badge component with default props", () => {
-    render(
-      <Badge>Badge</Badge>
-    );
+    render(<Badge>Badge</Badge>);
   });
 });


### PR DESCRIPTION
Why: As the text prop is no longer supported, I have modified the test to remove this prop. The text is now a child of Badge. 