### PR TITLE
feat: adds click event to legend items

### DIFF
--- a/src/components/text-elements/Legend/Legend.tsx
+++ b/src/components/text-elements/Legend/Legend.tsx
@@ -18,9 +18,10 @@ const makeLegendClassName = makeClassName("Legend");
 export interface LegendItemProps {
   name: string;
   color: Color;
+  itemOnClick?: (category: string) => void;
 }
 
-const LegendItem = ({ name, color }: LegendItemProps) => (
+const LegendItem = ({ name, color, itemOnClick }: LegendItemProps) => (
   <li
     className={twMerge(
       makeLegendClassName("legendItem"),
@@ -28,6 +29,7 @@ const LegendItem = ({ name, color }: LegendItemProps) => (
       getColorClassNames(DEFAULT_COLOR, colorPalette.text).textColor,
       spacing.md.marginRight,
     )}
+    onClick={() => (itemOnClick ? itemOnClick(name) : null)}
   >
     <svg
       className={twMerge(
@@ -51,10 +53,11 @@ const LegendItem = ({ name, color }: LegendItemProps) => (
 export interface LegendProps extends React.OlHTMLAttributes<HTMLOListElement> {
   categories: string[];
   colors?: Color[];
+  itemOnClick?: (category: string) => void;
 }
 
 const Legend = React.forwardRef<HTMLOListElement, LegendProps>((props, ref) => {
-  const { categories, colors = themeColorRange, className, ...other } = props;
+  const { categories, colors = themeColorRange, className, itemOnClick, ...other } = props;
   return (
     <ol
       ref={ref}
@@ -66,7 +69,12 @@ const Legend = React.forwardRef<HTMLOListElement, LegendProps>((props, ref) => {
       {...other}
     >
       {categories.map((category, idx) => (
-        <LegendItem key={`item-${idx}`} name={category} color={colors[idx]} />
+        <LegendItem
+          key={`item-${idx}`}
+          name={category}
+          color={colors[idx]}
+          itemOnClick={itemOnClick}
+        />
       ))}
     </ol>
   );

--- a/src/stories/text-elements/Legend.stories.tsx
+++ b/src/stories/text-elements/Legend.stories.tsx
@@ -27,3 +27,16 @@ Default.args = {
     "Category D",
   ],
 };
+
+export const WithClickEvent = Template.bind({});
+WithClickEvent.args = {
+  categories: [
+    "Critical",
+    "This is a very long category name to test an edge case",
+    "Category C",
+    "Category D",
+  ],
+  itemOnClick: (category: string) => {
+    alert(`You clicked: ${category}`);
+  },
+};

--- a/src/tests/text-elements/Legend.test.tsx
+++ b/src/tests/text-elements/Legend.test.tsx
@@ -7,4 +7,15 @@ describe("Legend", () => {
   test("renders the Legend component with default props", () => {
     render(<Legend categories={["Category A", "Category B", "Category C", "Category D"]} />);
   });
+
+  test("renders the Legend component with a click event", () => {
+    render(
+      <Legend
+        categories={["Category A", "Category B", "Category C", "Category D"]}
+        itemOnClick={(category) => {
+          alert(category);
+        }}
+      />,
+    );
+  });
 });


### PR DESCRIPTION
I created this draft as conversation starter for the feature I requested in issue #371. There's likely quite a bit more work required to complete this feature, but wanted to begin the implementation to gauge how big the effort would be and the level of interest in including this in the library.

This PR only includes code for adding an `itemClick` event to Legend Items. Future work required to enable filtering would include allowing an implementer to pass the click event through another component, e.g. the `AreaChart`, at the very least.