### PR TITLE
feat: allow axis customization on charts

### DIFF
--- a/src/components/chart-elements/AreaChart/AreaChart.tsx
+++ b/src/components/chart-elements/AreaChart/AreaChart.tsx
@@ -75,7 +75,7 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>((props, ref) 
             axisLine={false}
             padding={{ left: 10, right: 10 }}
             minTickGap={5}
-            {...xAxisConfig}
+            allowDecimals={xAxisConfig?.allowDecimals}
           />
           <YAxis
             width={yAxisWidth}
@@ -89,7 +89,7 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>((props, ref) 
               fontSize: "12px",
               fontFamily: "Inter; Helvetica",
             }}
-            {...yAxisConfig}
+            allowDecimals={yAxisConfig?.allowDecimals}
             tickFormatter={valueFormatter}
           />
           {showTooltip ? (

--- a/src/components/chart-elements/AreaChart/AreaChart.tsx
+++ b/src/components/chart-elements/AreaChart/AreaChart.tsx
@@ -9,6 +9,8 @@ import {
   Tooltip,
   XAxis,
   YAxis,
+  YAxisProps,
+  XAxisProps,
 } from "recharts";
 
 import { constructCategoryColors, getYAxisDomain } from "../common/utils";
@@ -30,6 +32,8 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>((props, ref) 
     index,
     stack = false,
     colors = themeColorRange,
+    yAxisConfig,
+    xAxisConfig,
     valueFormatter = defaultValueFormatter,
     startEndOnly = false,
     showXAxis = true,
@@ -73,6 +77,7 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>((props, ref) 
             axisLine={false}
             padding={{ left: 10, right: 10 }}
             minTickGap={5}
+            {...xAxisConfig}
           />
           <YAxis
             width={yAxisWidth}
@@ -86,6 +91,7 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>((props, ref) 
               fontSize: "12px",
               fontFamily: "Inter; Helvetica",
             }}
+            {...yAxisConfig}
             tickFormatter={valueFormatter}
           />
           {showTooltip ? (

--- a/src/components/chart-elements/AreaChart/AreaChart.tsx
+++ b/src/components/chart-elements/AreaChart/AreaChart.tsx
@@ -30,8 +30,7 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>((props, ref) 
     index,
     stack = false,
     colors = themeColorRange,
-    yAxisConfig,
-    xAxisConfig,
+    allowDecimals,
     valueFormatter = defaultValueFormatter,
     startEndOnly = false,
     showXAxis = true,
@@ -75,7 +74,6 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>((props, ref) 
             axisLine={false}
             padding={{ left: 10, right: 10 }}
             minTickGap={5}
-            allowDecimals={xAxisConfig?.allowDecimals}
           />
           <YAxis
             width={yAxisWidth}
@@ -89,7 +87,7 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>((props, ref) 
               fontSize: "12px",
               fontFamily: "Inter; Helvetica",
             }}
-            allowDecimals={yAxisConfig?.allowDecimals}
+            allowDecimals={allowDecimals}
             tickFormatter={valueFormatter}
           />
           {showTooltip ? (

--- a/src/components/chart-elements/AreaChart/AreaChart.tsx
+++ b/src/components/chart-elements/AreaChart/AreaChart.tsx
@@ -9,8 +9,6 @@ import {
   Tooltip,
   XAxis,
   YAxis,
-  YAxisProps,
-  XAxisProps,
 } from "recharts";
 
 import { constructCategoryColors, getYAxisDomain } from "../common/utils";

--- a/src/components/chart-elements/BarChart/BarChart.tsx
+++ b/src/components/chart-elements/BarChart/BarChart.tsx
@@ -87,7 +87,7 @@ const BarChart = React.forwardRef<HTMLDivElement, BarChartProps>((props, ref) =>
               }}
               tickLine={false}
               axisLine={false}
-              {...xAxisConfig}
+              allowDecimals={xAxisConfig?.allowDecimals}
             />
           ) : (
             <XAxis
@@ -103,7 +103,7 @@ const BarChart = React.forwardRef<HTMLDivElement, BarChartProps>((props, ref) =>
               axisLine={false}
               padding={{ left: 10, right: 10 }}
               minTickGap={5}
-              {...xAxisConfig}
+              allowDecimals={xAxisConfig?.allowDecimals}
               tickFormatter={valueFormatter}
             />
           )}
@@ -120,7 +120,7 @@ const BarChart = React.forwardRef<HTMLDivElement, BarChartProps>((props, ref) =>
                 fontSize: "12px",
                 fontFamily: "Inter; Helvetica",
               }}
-              {...yAxisConfig}
+              allowDecimals={yAxisConfig?.allowDecimals}
               tickFormatter={
                 relative ? (value: number) => `${(value * 100).toString()} %` : valueFormatter
               }
@@ -140,7 +140,7 @@ const BarChart = React.forwardRef<HTMLDivElement, BarChartProps>((props, ref) =>
                 fontSize: "12px",
                 fontFamily: "Inter; Helvetica",
               }}
-              {...yAxisConfig}
+              allowDecimals={yAxisConfig?.allowDecimals}
             />
           )}
           {showTooltip ? (

--- a/src/components/chart-elements/BarChart/BarChart.tsx
+++ b/src/components/chart-elements/BarChart/BarChart.tsx
@@ -48,8 +48,7 @@ const BarChart = React.forwardRef<HTMLDivElement, BarChartProps>((props, ref) =>
     minValue,
     maxValue,
     className,
-    yAxisConfig,
-    xAxisConfig,
+    allowDecimals,
     ...other
   } = props;
   const [legendHeight, setLegendHeight] = useState(60);
@@ -87,7 +86,6 @@ const BarChart = React.forwardRef<HTMLDivElement, BarChartProps>((props, ref) =>
               }}
               tickLine={false}
               axisLine={false}
-              allowDecimals={xAxisConfig?.allowDecimals}
             />
           ) : (
             <XAxis
@@ -101,10 +99,10 @@ const BarChart = React.forwardRef<HTMLDivElement, BarChartProps>((props, ref) =>
               }}
               tickLine={false}
               axisLine={false}
+              tickFormatter={valueFormatter}
               padding={{ left: 10, right: 10 }}
               minTickGap={5}
-              allowDecimals={xAxisConfig?.allowDecimals}
-              tickFormatter={valueFormatter}
+              allowDecimals={allowDecimals}
             />
           )}
           {layout !== "vertical" ? (
@@ -120,7 +118,7 @@ const BarChart = React.forwardRef<HTMLDivElement, BarChartProps>((props, ref) =>
                 fontSize: "12px",
                 fontFamily: "Inter; Helvetica",
               }}
-              allowDecimals={yAxisConfig?.allowDecimals}
+              allowDecimals={allowDecimals}
               tickFormatter={
                 relative ? (value: number) => `${(value * 100).toString()} %` : valueFormatter
               }
@@ -140,7 +138,6 @@ const BarChart = React.forwardRef<HTMLDivElement, BarChartProps>((props, ref) =>
                 fontSize: "12px",
                 fontFamily: "Inter; Helvetica",
               }}
-              allowDecimals={yAxisConfig?.allowDecimals}
             />
           )}
           {showTooltip ? (

--- a/src/components/chart-elements/BarChart/BarChart.tsx
+++ b/src/components/chart-elements/BarChart/BarChart.tsx
@@ -48,6 +48,8 @@ const BarChart = React.forwardRef<HTMLDivElement, BarChartProps>((props, ref) =>
     minValue,
     maxValue,
     className,
+    yAxisConfig,
+    xAxisConfig,
     ...other
   } = props;
   const [legendHeight, setLegendHeight] = useState(60);
@@ -85,6 +87,7 @@ const BarChart = React.forwardRef<HTMLDivElement, BarChartProps>((props, ref) =>
               }}
               tickLine={false}
               axisLine={false}
+              {...xAxisConfig}
             />
           ) : (
             <XAxis
@@ -98,9 +101,10 @@ const BarChart = React.forwardRef<HTMLDivElement, BarChartProps>((props, ref) =>
               }}
               tickLine={false}
               axisLine={false}
-              tickFormatter={valueFormatter}
               padding={{ left: 10, right: 10 }}
               minTickGap={5}
+              {...xAxisConfig}
+              tickFormatter={valueFormatter}
             />
           )}
           {layout !== "vertical" ? (
@@ -116,6 +120,7 @@ const BarChart = React.forwardRef<HTMLDivElement, BarChartProps>((props, ref) =>
                 fontSize: "12px",
                 fontFamily: "Inter; Helvetica",
               }}
+              {...yAxisConfig}
               tickFormatter={
                 relative ? (value: number) => `${(value * 100).toString()} %` : valueFormatter
               }
@@ -135,6 +140,7 @@ const BarChart = React.forwardRef<HTMLDivElement, BarChartProps>((props, ref) =>
                 fontSize: "12px",
                 fontFamily: "Inter; Helvetica",
               }}
+              {...yAxisConfig}
             />
           )}
           {showTooltip ? (

--- a/src/components/chart-elements/LineChart/LineChart.tsx
+++ b/src/components/chart-elements/LineChart/LineChart.tsx
@@ -38,8 +38,7 @@ const LineChart = React.forwardRef<HTMLDivElement, BaseChartProps>((props, ref) 
     minValue,
     maxValue,
     className,
-    yAxisConfig,
-    xAxisConfig,
+    allowDecimals,
     ...other
   } = props;
   const [legendHeight, setLegendHeight] = useState(60);
@@ -68,7 +67,6 @@ const LineChart = React.forwardRef<HTMLDivElement, BaseChartProps>((props, ref) 
             axisLine={false}
             padding={{ left: 10, right: 10 }}
             minTickGap={5}
-            allowDecimals={xAxisConfig?.allowDecimals}
           />
           <YAxis
             width={yAxisWidth}
@@ -82,7 +80,7 @@ const LineChart = React.forwardRef<HTMLDivElement, BaseChartProps>((props, ref) 
               fontSize: "12px",
               fontFamily: "Inter; Helvetica",
             }}
-            allowDecimals={yAxisConfig?.allowDecimals}
+            allowDecimals={allowDecimals}
             tickFormatter={valueFormatter}
           />
           {showTooltip ? (

--- a/src/components/chart-elements/LineChart/LineChart.tsx
+++ b/src/components/chart-elements/LineChart/LineChart.tsx
@@ -68,7 +68,7 @@ const LineChart = React.forwardRef<HTMLDivElement, BaseChartProps>((props, ref) 
             axisLine={false}
             padding={{ left: 10, right: 10 }}
             minTickGap={5}
-            {...xAxisConfig}
+            allowDecimals={xAxisConfig?.allowDecimals}
           />
           <YAxis
             width={yAxisWidth}
@@ -82,7 +82,7 @@ const LineChart = React.forwardRef<HTMLDivElement, BaseChartProps>((props, ref) 
               fontSize: "12px",
               fontFamily: "Inter; Helvetica",
             }}
-            {...yAxisConfig}
+            allowDecimals={yAxisConfig?.allowDecimals}
             tickFormatter={valueFormatter}
           />
           {showTooltip ? (

--- a/src/components/chart-elements/LineChart/LineChart.tsx
+++ b/src/components/chart-elements/LineChart/LineChart.tsx
@@ -38,6 +38,8 @@ const LineChart = React.forwardRef<HTMLDivElement, BaseChartProps>((props, ref) 
     minValue,
     maxValue,
     className,
+    yAxisConfig,
+    xAxisConfig,
     ...other
   } = props;
   const [legendHeight, setLegendHeight] = useState(60);
@@ -66,6 +68,7 @@ const LineChart = React.forwardRef<HTMLDivElement, BaseChartProps>((props, ref) 
             axisLine={false}
             padding={{ left: 10, right: 10 }}
             minTickGap={5}
+            {...xAxisConfig}
           />
           <YAxis
             width={yAxisWidth}
@@ -79,6 +82,7 @@ const LineChart = React.forwardRef<HTMLDivElement, BaseChartProps>((props, ref) 
               fontSize: "12px",
               fontFamily: "Inter; Helvetica",
             }}
+            {...yAxisConfig}
             tickFormatter={valueFormatter}
           />
           {showTooltip ? (

--- a/src/components/chart-elements/common/BaseChartProps.tsx
+++ b/src/components/chart-elements/common/BaseChartProps.tsx
@@ -1,5 +1,5 @@
 import { Color, ValueFormatter } from "../../../lib";
-import {XAxisProps, YAxisProps} from "recharts";
+import { XAxisProps, YAxisProps } from "recharts";
 
 interface BaseChartProps extends React.HTMLAttributes<HTMLDivElement> {
   data: any[];

--- a/src/components/chart-elements/common/BaseChartProps.tsx
+++ b/src/components/chart-elements/common/BaseChartProps.tsx
@@ -1,5 +1,5 @@
 import { Color, ValueFormatter } from "../../../lib";
-import { XAxisProps, YAxisProps } from "recharts";
+import type { XAxisProps, YAxisProps } from "recharts";
 
 interface BaseChartProps extends React.HTMLAttributes<HTMLDivElement> {
   data: any[];

--- a/src/components/chart-elements/common/BaseChartProps.tsx
+++ b/src/components/chart-elements/common/BaseChartProps.tsx
@@ -1,5 +1,4 @@
 import { Color, ValueFormatter } from "../../../lib";
-import type { XAxisProps, YAxisProps } from "recharts";
 
 interface BaseChartProps extends React.HTMLAttributes<HTMLDivElement> {
   data: any[];
@@ -19,8 +18,7 @@ interface BaseChartProps extends React.HTMLAttributes<HTMLDivElement> {
   autoMinValue?: boolean;
   minValue?: number;
   maxValue?: number;
-  yAxisConfig?: Pick<YAxisProps, "allowDecimals">;
-  xAxisConfig?: Pick<XAxisProps, "allowDecimals">;
+  allowDecimals?: boolean;
 }
 
 export default BaseChartProps;

--- a/src/components/chart-elements/common/BaseChartProps.tsx
+++ b/src/components/chart-elements/common/BaseChartProps.tsx
@@ -1,4 +1,5 @@
 import { Color, ValueFormatter } from "../../../lib";
+import {XAxisProps, YAxisProps} from "recharts";
 
 interface BaseChartProps extends React.HTMLAttributes<HTMLDivElement> {
   data: any[];
@@ -18,6 +19,8 @@ interface BaseChartProps extends React.HTMLAttributes<HTMLDivElement> {
   autoMinValue?: boolean;
   minValue?: number;
   maxValue?: number;
+  yAxisConfig?: Pick<YAxisProps, "allowDecimals">;
+  xAxisConfig?: Pick<XAxisProps, "allowDecimals">;
 }
 
 export default BaseChartProps;


### PR DESCRIPTION
* Resolves #394

Add optoinal yAxisConfig and xAxisConfig options to BaseChartProps.
Currently, we can only provide allowDecimal option as these configs.