### PR TITLE
ci: build release & rm major

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,8 +121,8 @@
           "preset": "conventionalcommits",
           "releaseRules": [
             {
-              "type": "*!",
-              "release": "major"
+              "type": "build",
+              "release": "minor"
             }
           ]
         }


### PR DESCRIPTION
Adds a `build` minor release to the config and removes breaking change releases that are triggered with an exclamation mark.