### PR TITLE
feat: allow connectNulls customization on some charts

### DIFF
--- a/src/components/chart-elements/AreaChart/AreaChart.tsx
+++ b/src/components/chart-elements/AreaChart/AreaChart.tsx
@@ -21,6 +21,7 @@ import { AxisDomain } from "recharts/types/util/types";
 
 export interface AreaChartProps extends BaseChartProps {
   stack?: boolean;
+  connectNulls?: boolean;
 }
 
 const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>((props, ref) => {
@@ -43,6 +44,7 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>((props, ref) 
     autoMinValue = false,
     minValue,
     maxValue,
+    connectNulls = false,
     className,
     ...other
   } = props;
@@ -144,6 +146,7 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>((props, ref) 
               dot={false}
               isAnimationActive={showAnimation}
               stackId={stack ? "a" : undefined}
+              connectNulls={connectNulls}
             />
           ))}
         </ReChartsAreaChart>

--- a/src/components/chart-elements/LineChart/LineChart.tsx
+++ b/src/components/chart-elements/LineChart/LineChart.tsx
@@ -41,7 +41,7 @@ const LineChart = React.forwardRef<HTMLDivElement, LineChartProps>((props, ref) 
     autoMinValue = false,
     minValue,
     maxValue,
-    connectNulls,
+    connectNulls = false,
     className,
     ...other
   } = props;

--- a/src/components/chart-elements/LineChart/LineChart.tsx
+++ b/src/components/chart-elements/LineChart/LineChart.tsx
@@ -19,7 +19,11 @@ import ChartTooltip from "../common/ChartTooltip";
 import { BaseColors, defaultValueFormatter, hexColors, themeColorRange } from "lib";
 import { AxisDomain } from "recharts/types/util/types";
 
-const LineChart = React.forwardRef<HTMLDivElement, BaseChartProps>((props, ref) => {
+export interface LineChartProps extends BaseChartProps {
+  connectNulls?: boolean;
+}
+
+const LineChart = React.forwardRef<HTMLDivElement, LineChartProps>((props, ref) => {
   const {
     data = [],
     categories = [],
@@ -37,6 +41,7 @@ const LineChart = React.forwardRef<HTMLDivElement, BaseChartProps>((props, ref) 
     autoMinValue = false,
     minValue,
     maxValue,
+    connectNulls,
     className,
     ...other
   } = props;
@@ -116,6 +121,7 @@ const LineChart = React.forwardRef<HTMLDivElement, BaseChartProps>((props, ref) 
               strokeWidth={2}
               dot={false}
               isAnimationActive={showAnimation}
+              connectNulls={connectNulls}
             />
           ))}
         </ReChartsLineChart>

--- a/src/stories/chart-elements/AreaChart.stories.tsx
+++ b/src/stories/chart-elements/AreaChart.stories.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 
 import { AreaChart, Card, Title } from "components";
-import { simpleBaseChartData as data } from "./helpers/testData";
+import { simpleBaseChartData as data, simpleBaseChartDataWithNulls } from "./helpers/testData";
 import { valueFormatter } from "./helpers/utils";
 
 // More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
@@ -145,5 +145,18 @@ WithNoCategories.args = {
 export const WithNoDataKey = DefaultTemplate.bind({});
 WithNoDataKey.args = {
   data: data,
+  categories: ["Sales", "Successful Payments"],
+};
+
+export const WithConnectNullsTrue = DefaultTemplate.bind({});
+WithConnectNullsTrue.args = {
+  data: simpleBaseChartDataWithNulls,
+  connectNulls: true,
+  categories: ["Sales", "Successful Payments"],
+};
+
+export const WithConnectNullsFalse = DefaultTemplate.bind({});
+WithConnectNullsFalse.args = {
+  data: simpleBaseChartDataWithNulls,
   categories: ["Sales", "Successful Payments"],
 };

--- a/src/stories/chart-elements/LineChart.stories.tsx
+++ b/src/stories/chart-elements/LineChart.stories.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 
 import { Card, LineChart, Title } from "components";
-import { simpleBaseChartData as data } from "./helpers/testData";
+import { simpleBaseChartData as data, simpleBaseChartDataWithNulls } from "./helpers/testData";
 import { valueFormatter } from "stories/chart-elements/helpers/utils";
 
 // More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
@@ -134,5 +134,18 @@ WithNoCategories.args = {
 export const WithNoDataKey = DefaultTemplate.bind({});
 WithNoDataKey.args = {
   data: data,
+  categories: ["Sales", "Successful Payments"],
+};
+
+export const WithConnectNullsTrue = DefaultTemplate.bind({});
+WithConnectNullsTrue.args = {
+  data: simpleBaseChartDataWithNulls,
+  connectNulls: true,
+  categories: ["Sales", "Successful Payments"],
+};
+
+export const WithConnectNullsFalse = DefaultTemplate.bind({});
+WithConnectNullsFalse.args = {
+  data: simpleBaseChartDataWithNulls,
   categories: ["Sales", "Successful Payments"],
 };

--- a/src/stories/chart-elements/helpers/testData.tsx
+++ b/src/stories/chart-elements/helpers/testData.tsx
@@ -50,6 +50,56 @@ export const simpleBaseChartData = [
   },
 ];
 
+export const simpleBaseChartDataWithNulls = [
+  {
+    month: "Jan 21'",
+    Sales: 4000,
+    "Successful Payments": 3000,
+    "This is an edge case": 100000000,
+    Test: 5000,
+  },
+  {
+    month: "Feb 21'",
+    Sales: 3000,
+    "Successful Payments": 2000,
+    "This is an edge case": 100000000,
+    Test: 5000,
+  },
+  {
+    month: "Mar 21'",
+    Sales: 2000,
+    "Successful Payments": 1700,
+    "This is an edge case": 100000000,
+    Test: 5000,
+  },
+  {
+    month: "Apr 21'",
+    "Successful Payments": 2500,
+    "This is an edge case": 100000000,
+    Test: 5000,
+  },
+  {
+    month: "May 21",
+    "Successful Payments": 1000,
+    "This is an edge case": 100000000,
+    Test: 5000,
+  },
+  {
+    month: "Jun 21'",
+    Sales: 2390,
+    "Successful Payments": 2000,
+    "This is an edge case": 100000000,
+    Test: 5000,
+  },
+  {
+    month: "Jul 21'",
+    Sales: 3490,
+    "Successful Payments": 3000,
+    "This is an edge case": 100000000,
+    Test: 5000,
+  },
+];
+
 export const simpleSingleCategoryData = [
   {
     city: "San Francisco",


### PR DESCRIPTION
What - whether to connect a graph area across null points.
Why - connectNulls is a simple feature that doesn't detract from tremor's simplicity and makes the chart look more natural.
How - add connectNulls property on AreaChart, LineChart
Testing - in the storybook, remove one value in the middle of the data and replace connectNulls with true.

### Before
![CleanShot 2023-04-20 at 13 30 52](https://user-images.githubusercontent.com/9105017/233258659-bb111723-1951-4944-90b3-46c93cc2ba60.png)

### After
![CleanShot 2023-04-20 at 13 31 30](https://user-images.githubusercontent.com/9105017/233258724-35326033-d74f-4008-ab9c-e3d6d4ac83cb.png)

### Reference
https://recharts.org/en-US/api/Area#connectNulls
https://recharts.org/en-US/api/Line#connectNulls
