### PR TITLE
fix: relative import CurveType

### DIFF
--- a/src/components/chart-elements/AreaChart/AreaChart.tsx
+++ b/src/components/chart-elements/AreaChart/AreaChart.tsx
@@ -16,7 +16,8 @@ import BaseChartProps from "../common/BaseChartProps";
 import ChartLegend from "../common/ChartLegend";
 import ChartTooltip from "../common/ChartTooltip";
 
-import { BaseColors, CurveType, defaultValueFormatter, hexColors, themeColorRange } from "lib";
+import { BaseColors, defaultValueFormatter, hexColors, themeColorRange } from "lib";
+import { CurveType } from "../../../lib/inputTypes";
 import { AxisDomain } from "recharts/types/util/types";
 
 export interface AreaChartProps extends BaseChartProps {

--- a/src/components/chart-elements/LineChart/LineChart.tsx
+++ b/src/components/chart-elements/LineChart/LineChart.tsx
@@ -16,7 +16,8 @@ import BaseChartProps from "../common/BaseChartProps";
 import ChartLegend from "components/chart-elements/common/ChartLegend";
 import ChartTooltip from "../common/ChartTooltip";
 
-import { BaseColors, CurveType, defaultValueFormatter, hexColors, themeColorRange } from "lib";
+import { BaseColors, defaultValueFormatter, hexColors, themeColorRange } from "lib";
+import { CurveType } from "../../../lib/inputTypes";
 import { AxisDomain } from "recharts/types/util/types";
 
 export interface LineChartProps extends BaseChartProps {


### PR DESCRIPTION
Makes `CurveType` a relative import so that rollup can resolve it.