### PR TITLE
fix: replace the `p` tag inside buttons with `span`

### DIFF
--- a/src/components/input-elements/Button/Button.tsx
+++ b/src/components/input-elements/Button/Button.tsx
@@ -145,9 +145,9 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => 
             />
           ) : null}
           {
-            <p className={twMerge(makeButtonClassName("text"), "text-sm whitespace-nowrap")}>
+            <span className={twMerge(makeButtonClassName("text"), "text-sm whitespace-nowrap")}>
               {showLoadingText ? loadingText : children}
-            </p>
+            </span>
           }
           {showButtonIconOrSpinner && iconPosition === HorizontalPositions.Right ? (
             <ButtonIconOrSpinner


### PR DESCRIPTION
Related: https://github.com/tremorlabs/tremor/issues/440#issue-1698924812

I replaced the `p` tag inside the `Button` component with a `span` for two reasons:
1. It's not valid HTML
2. If someone puts a `<div>` inside the Button, for some reason it breaks Next.js hydration and it's very hard to debug. For example I did something like this the other day:
```tsx
<Button>
  <Flex>
    <span>Click me</span>
    <AnIcon />
  </Flex>
</Button>
```
Because I wanted to have more control over the `AnIcon` props and it broke Next.js hydration.

This is the error:
```
uncaught Error: Hydration failed because the initial UI does not match what was rendered on the server.
 
warning: validateDOMNesting(...): <div> cannot appear as a descendant of <p>.
```

Fortunately I did know that `Button` renders a `p` around its content and a `div` inside `p` beaks hydration but not all people know that.

A `<div>` inside a `<span>` might not be valid HTML but at least users don't have to deal with the hydration error.

It was such a simple change that I didn't test it locally. Sorry for my laziness. But hopefully it doesn't break anything