### PR TITLE
fix: dropdown max height

### DIFF
--- a/src/components/util-elements/Modal/Modal.tsx
+++ b/src/components/util-elements/Modal/Modal.tsx
@@ -23,7 +23,7 @@ const Modal = React.forwardRef<HTMLDivElement, ModalProps>((props, ref) => {
     setShowModal,
     parentRef,
     width,
-    maxHeight = "max-h-72",
+    maxHeight = "max-h-[228px]",
     children,
     className,
     ...other
@@ -75,7 +75,7 @@ const Modal = React.forwardRef<HTMLDivElement, ModalProps>((props, ref) => {
     <div
       ref={mergeRefs([modalRef, ref])}
       className={twMerge(
-        "absolute z-10 divide-y overflow-y-auto",
+        "absolute z-10 divide-y overflow-y-scroll",
         width ? "" : "w-full",
         getAbsoluteSpacing(),
         maxHeight,

--- a/src/stories/input-elements/Dropdown.stories.tsx
+++ b/src/stories/input-elements/Dropdown.stories.tsx
@@ -89,6 +89,12 @@ const WithControlledStateTemplate: ComponentStory<typeof Dropdown> = () => {
         <DropdownItem value={"5"} text={"Five"} />
         <DropdownItem value={"3"} text={"Three"} />
         <DropdownItem value={"1"} text={"One"} />
+        <DropdownItem value={"6"} text={"Six"} />
+        <DropdownItem value={"7"} text={"Seven"} />
+        <DropdownItem value={"8"} text={"Eight"} />
+        <DropdownItem value={"9"} text={"Nine"} />
+        <DropdownItem value={"10"} text={"Ten"} />
+        <DropdownItem value={"11"} text={"Eleven"} />
       </Dropdown>
       <Button onClick={() => setValue("")}>Reset</Button>
       <Button onClick={() => setValue("1")}>Set to One</Button>


### PR DESCRIPTION
Decreases the max height of a dropdown such that it is more obvious that it contains more elements:
<img width="399" alt="image" src="https://user-images.githubusercontent.com/58337217/236688903-3423332a-a487-4a5b-b822-161eb128cb76.png">
