### PR TITLE
fix: replace the `p` tag inside buttons with `span`

### DIFF
--- a/src/components/input-elements/Button/Button.tsx
+++ b/src/components/input-elements/Button/Button.tsx
@@ -145,9 +145,9 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => 
             />
           ) : null}
           {
-            <p className={twMerge(makeButtonClassName("text"), "text-sm whitespace-nowrap")}>
+            <span className={twMerge(makeButtonClassName("text"), "text-sm whitespace-nowrap")}>
               {showLoadingText ? loadingText : children}
-            </p>
+            </span>
           }
           {showButtonIconOrSpinner && iconPosition === HorizontalPositions.Right ? (
             <ButtonIconOrSpinner


### PR DESCRIPTION
Resolves #440 

I replaced the `p` tag inside the button with `span` for two reasons:
1. It's not valid HTML
2. If someone puts a `<div>` inside the button, for some reason it breaks Next.js hydration and it's a pain in the ass to debug. For example I did something like this the other day:
```tsx
<Button>
  <Flex>
    <span>Click me</span>
    <AnIcon />
  </Flex>
</Button>
```
Because I wanted to have more control over the icon props an it broke Next.js hydration. Hopefully I did know that `Button` renders a `p` around its content and a `div` inside `p` beaks hydration but not all people know that.