### PR TITLE
feat: export component types & clean-up exports

### DIFF
--- a/src/components/chart-elements/AreaChart/index.ts
+++ b/src/components/chart-elements/AreaChart/index.ts
@@ -1,1 +1,2 @@
-export { default } from "./AreaChart";
+export { default as AreaChart } from "./AreaChart";
+export type { AreaChartProps } from "./AreaChart";

--- a/src/components/chart-elements/BarChart/index.ts
+++ b/src/components/chart-elements/BarChart/index.ts
@@ -1,1 +1,2 @@
-export { default } from "./BarChart";
+export { default as BarChart } from "./BarChart";
+export type { BarChartProps } from "./BarChart";

--- a/src/components/chart-elements/DonutChart/index.ts
+++ b/src/components/chart-elements/DonutChart/index.ts
@@ -1,1 +1,2 @@
-export { default } from "./DonutChart";
+export { default as DonutChart } from "./DonutChart";
+export type { DonutChartProps } from "./DonutChart";

--- a/src/components/chart-elements/LineChart/index.ts
+++ b/src/components/chart-elements/LineChart/index.ts
@@ -1,1 +1,2 @@
-export { default } from "./LineChart";
+export { default as LineChart } from "./LineChart";
+export type { LineChartProps } from "./LineChart";

--- a/src/components/chart-elements/common/ChartLegend.tsx
+++ b/src/components/chart-elements/common/ChartLegend.tsx
@@ -3,7 +3,7 @@ import React, { useRef } from "react";
 import { useOnWindowResize } from "hooks";
 
 import { Color } from "../../../lib";
-import Legend from "components/text-elements/Legend";
+import { Legend } from "components/text-elements/Legend";
 
 const ChartLegend = (
   { payload }: any,

--- a/src/components/chart-elements/index.ts
+++ b/src/components/chart-elements/index.ts
@@ -1,4 +1,4 @@
-export { default as AreaChart } from "./AreaChart";
-export { default as BarChart } from "./BarChart";
-export { default as LineChart } from "./LineChart";
-export { default as DonutChart } from "./DonutChart";
+export * from "./AreaChart";
+export * from "./BarChart";
+export * from "./LineChart";
+export * from "./DonutChart";

--- a/src/components/icon-elements/Badge/index.ts
+++ b/src/components/icon-elements/Badge/index.ts
@@ -1,1 +1,2 @@
-export { default } from "./Badge";
+export { default as Badge } from "./Badge";
+export type { BadgeProps } from "./Badge";

--- a/src/components/icon-elements/BadgeDelta/index.ts
+++ b/src/components/icon-elements/BadgeDelta/index.ts
@@ -1,0 +1,2 @@
+export { default as BadgeDelta } from "./BadgeDelta";
+export type { BadgeDeltaProps } from "./BadgeDelta";

--- a/src/components/icon-elements/BadgeDelta/index.tsx
+++ b/src/components/icon-elements/BadgeDelta/index.tsx
@@ -1,1 +1,0 @@
-export { default } from "./BadgeDelta";

--- a/src/components/icon-elements/Icon/index.ts
+++ b/src/components/icon-elements/Icon/index.ts
@@ -1,1 +1,2 @@
-export { default } from "./Icon";
+export { default as Icon } from "./Icon";
+export type { IconProps } from "./Icon";

--- a/src/components/icon-elements/index.ts
+++ b/src/components/icon-elements/index.ts
@@ -1,4 +1,3 @@
-export { default as Badge } from "./Badge";
-export { default as BadgeDelta } from "./BadgeDelta";
-
-export { default as Icon } from "./Icon";
+export * from "./Badge";
+export * from "./BadgeDelta";
+export * from "./Icon";

--- a/src/components/input-elements/Button/index.ts
+++ b/src/components/input-elements/Button/index.ts
@@ -1,1 +1,2 @@
-export { default } from "./Button";
+export { default as Button } from "./Button";
+export type { ButtonProps } from "./Button";

--- a/src/components/input-elements/DateRangePicker/DateRangePicker.tsx
+++ b/src/components/input-elements/DateRangePicker/DateRangePicker.tsx
@@ -22,7 +22,7 @@ import {
 import Calendar from "./Calendar";
 import DateRangePickerButton from "./DateRangePickerButton";
 import { DropdownItem } from "components/input-elements/Dropdown";
-import Modal from "components/util-elements/Modal";
+import { Modal } from "components/util-elements/Modal";
 
 export type Locale = typeof enUS;
 

--- a/src/components/input-elements/DateRangePicker/index.ts
+++ b/src/components/input-elements/DateRangePicker/index.ts
@@ -1,3 +1,2 @@
 export { default as DateRangePicker } from "./DateRangePicker";
-
-export { DateRangePickerValue } from "./DateRangePicker";
+export type { DateRangePickerProps, DateRangePickerValue } from "./DateRangePicker";

--- a/src/components/input-elements/Dropdown/Dropdown.tsx
+++ b/src/components/input-elements/Dropdown/Dropdown.tsx
@@ -22,7 +22,7 @@ import {
 } from "lib";
 import { constructValueToNameMapping, getSelectButtonColors, hasValue } from "../selectUtils";
 import { DropdownItemProps } from "./DropdownItem";
-import Modal from "components/util-elements/Modal";
+import { Modal } from "components/util-elements/Modal";
 import { DEFAULT_COLOR, colorPalette } from "lib/theme";
 
 const makeDropdownClassName = makeClassName("Dropdown");

--- a/src/components/input-elements/Dropdown/index.ts
+++ b/src/components/input-elements/Dropdown/index.ts
@@ -1,2 +1,5 @@
 export { default as Dropdown } from "./Dropdown";
+export type { DropdownProps } from "./Dropdown";
+
 export { default as DropdownItem } from "./DropdownItem";
+export type { DropdownItemProps } from "./DropdownItem";

--- a/src/components/input-elements/MultiSelectBox/MultiSelectBox.tsx
+++ b/src/components/input-elements/MultiSelectBox/MultiSelectBox.tsx
@@ -22,7 +22,7 @@ import {
   spacing,
 } from "lib";
 import { getFilteredOptions, getSelectButtonColors } from "../selectUtils";
-import Modal from "components/util-elements/Modal";
+import { Modal } from "components/util-elements/Modal";
 import { MultiSelectBoxItemProps } from "./MultiSelectBoxItem";
 import { DEFAULT_COLOR, colorPalette } from "lib/theme";
 

--- a/src/components/input-elements/MultiSelectBox/index.ts
+++ b/src/components/input-elements/MultiSelectBox/index.ts
@@ -1,2 +1,5 @@
 export { default as MultiSelectBox } from "./MultiSelectBox";
+export type { MultiSelectBoxProps } from "./MultiSelectBox";
+
 export { default as MultiSelectBoxItem } from "./MultiSelectBoxItem";
+export type { MultiSelectBoxItemProps } from "./MultiSelectBoxItem";

--- a/src/components/input-elements/SelectBox/SelectBox.tsx
+++ b/src/components/input-elements/SelectBox/SelectBox.tsx
@@ -26,7 +26,7 @@ import {
   getSelectButtonColors,
   hasValue,
 } from "../selectUtils";
-import Modal from "components/util-elements/Modal";
+import { Modal } from "components/util-elements/Modal";
 import { SelectBoxItemProps } from "./SelectBoxItem";
 import { DEFAULT_COLOR, colorPalette } from "lib/theme";
 

--- a/src/components/input-elements/SelectBox/index.ts
+++ b/src/components/input-elements/SelectBox/index.ts
@@ -1,2 +1,5 @@
 export { default as SelectBox } from "./SelectBox";
+export type { SelectBoxProps } from "./SelectBox";
+
 export { default as SelectBoxItem } from "./SelectBoxItem";
+export type { SelectBoxItemProps } from "./SelectBoxItem";

--- a/src/components/input-elements/Tab/index.ts
+++ b/src/components/input-elements/Tab/index.ts
@@ -1,2 +1,5 @@
 export { default as Tab } from "./Tab";
+export type { TabProps } from "./Tab";
+
 export { default as TabList } from "./TabList";
+export type { TabListProps } from "./TabList";

--- a/src/components/input-elements/TextInput/index.ts
+++ b/src/components/input-elements/TextInput/index.ts
@@ -1,1 +1,2 @@
-export { default } from "./TextInput";
+export { default as TextInput } from "./TextInput";
+export type { TextInputProps } from "./TextInput";

--- a/src/components/input-elements/Toggle/index.ts
+++ b/src/components/input-elements/Toggle/index.ts
@@ -1,2 +1,5 @@
 export { default as Toggle } from "./Toggle";
+export type { ToggleProps } from "./Toggle";
+
 export { default as ToggleItem } from "./ToggleItem";
+export type { ToggleItemProps } from "./ToggleItem";

--- a/src/components/input-elements/index.ts
+++ b/src/components/input-elements/index.ts
@@ -3,7 +3,6 @@ export * from "./MultiSelectBox";
 export * from "./SelectBox";
 export * from "./Tab";
 export * from "./Toggle";
-
-export { default as Button } from "./Button";
+export * from "./Button";
 export * from "./DateRangePicker";
-export { default as TextInput } from "./TextInput";
+export * from "./TextInput";

--- a/src/components/layout-elements/Accordion/index.ts
+++ b/src/components/layout-elements/Accordion/index.ts
@@ -1,4 +1,11 @@
 export { default as Accordion } from "./Accordion";
+export type { AccordionProps } from "./Accordion";
+
 export { default as AccordionBody } from "./AccordionBody";
+export type { AccordionBodyProps } from "./AccordionBody";
+
 export { default as AccordionHeader } from "./AccordionHeader";
+export type { AccordionHeaderProps } from "./AccordionHeader";
+
 export { default as AccordionList } from "./AccordionList";
+export type { AccordionListProps } from "./AccordionList";

--- a/src/components/layout-elements/Card/index.ts
+++ b/src/components/layout-elements/Card/index.ts
@@ -1,1 +1,2 @@
-export { default } from "./Card";
+export { default as Card } from "./Card";
+export type { CardProps } from "./Card";

--- a/src/components/layout-elements/Divider/index.ts
+++ b/src/components/layout-elements/Divider/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./Divider";
+export { default as Divider } from "./Divider";

--- a/src/components/layout-elements/Flex/index.ts
+++ b/src/components/layout-elements/Flex/index.ts
@@ -1,1 +1,2 @@
-export { default } from "./Flex";
+export { default as Flex } from "./Flex";
+export type { FlexProps } from "./Flex";

--- a/src/components/layout-elements/Grid/index.ts
+++ b/src/components/layout-elements/Grid/index.ts
@@ -1,2 +1,5 @@
 export { default as Col } from "./Col";
+export type { ColProps } from "./Col";
+
 export { default as Grid } from "./Grid";
+export type { GridProps } from "./Grid";

--- a/src/components/layout-elements/index.ts
+++ b/src/components/layout-elements/index.ts
@@ -1,6 +1,5 @@
 export * from "./Accordion";
 export * from "./Grid";
-
-export { default as Card } from "./Card";
-export { default as Divider } from "./Divider";
-export { default as Flex } from "./Flex";
+export * from "./Card";
+export * from "./Divider";
+export * from "./Flex";

--- a/src/components/text-elements/Bold/index.ts
+++ b/src/components/text-elements/Bold/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./Bold";
+export { default as Bold } from "./Bold";

--- a/src/components/text-elements/Callout/index.ts
+++ b/src/components/text-elements/Callout/index.ts
@@ -1,1 +1,2 @@
-export { default } from "./Callout";
+export { default as Callout } from "./Callout";
+export type { CalloutProps } from "./Callout";

--- a/src/components/text-elements/Italic/index.ts
+++ b/src/components/text-elements/Italic/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./Italic";
+export { default as Italic } from "./Italic";

--- a/src/components/text-elements/Legend/index.ts
+++ b/src/components/text-elements/Legend/index.ts
@@ -1,1 +1,2 @@
-export { default } from "./Legend";
+export { default as Legend } from "./Legend";
+export type { LegendProps } from "./Legend";

--- a/src/components/text-elements/Metric/index.ts
+++ b/src/components/text-elements/Metric/index.ts
@@ -1,1 +1,2 @@
-export { default } from "./Metric";
+export { default as Metric } from "./Metric";
+export type { MetricProps } from "./Metric";

--- a/src/components/text-elements/Subtitle/index.ts
+++ b/src/components/text-elements/Subtitle/index.ts
@@ -1,1 +1,2 @@
-export { default } from "./Subtitle";
+export { default as Subtitle } from "./Subtitle";
+export type { SubtitleProps } from "./Subtitle";

--- a/src/components/text-elements/Text/index.ts
+++ b/src/components/text-elements/Text/index.ts
@@ -1,1 +1,2 @@
-export { default } from "./Text";
+export { default as Text } from "./Text";
+export type { TextProps } from "./Text";

--- a/src/components/text-elements/Title/index.ts
+++ b/src/components/text-elements/Title/index.ts
@@ -1,0 +1,2 @@
+export { default as Title } from "./Title";
+export type { TitleProps } from "./Title";

--- a/src/components/text-elements/Title/index.tsx
+++ b/src/components/text-elements/Title/index.tsx
@@ -1,1 +1,0 @@
-export { default } from "./Title";

--- a/src/components/text-elements/index.ts
+++ b/src/components/text-elements/index.ts
@@ -1,10 +1,8 @@
-export { default as Bold } from "./Bold";
-export { default as Italic } from "./Italic";
-
-export { default as Metric } from "./Metric";
-export { default as Subtitle } from "./Subtitle";
-export { default as Text } from "./Text";
-export { default as Title } from "./Title";
-
-export { default as Callout } from "./Callout";
-export { default as Legend } from "./Legend";
+export * from "./Text";
+export * from "./Bold";
+export * from "./Italic";
+export * from "./Title";
+export * from "./Subtitle";
+export * from "./Metric";
+export * from "./Callout";
+export * from "./Legend";

--- a/src/components/util-elements/Modal/index.ts
+++ b/src/components/util-elements/Modal/index.ts
@@ -1,1 +1,2 @@
-export { default } from "./Modal";
+export { default as Modal } from "./Modal";
+export type { ModalProps } from "./Modal";

--- a/src/components/util-elements/Tooltip/index.ts
+++ b/src/components/util-elements/Tooltip/index.ts
@@ -1,1 +1,2 @@
-export { default } from "./Tooltip";
+export { default as Tooltip } from "./Tooltip";
+export type { TooltipProps } from "./Tooltip";

--- a/src/components/util-elements/index.ts
+++ b/src/components/util-elements/index.ts
@@ -1,2 +1,2 @@
-export { default as Modal } from "./Modal";
-export { default as Tooltip } from "./Tooltip";
+export * from "./Modal";
+export * from "./Tooltip";

--- a/src/components/vis-elements/BarList/index.ts
+++ b/src/components/vis-elements/BarList/index.ts
@@ -1,1 +1,2 @@
-export { default } from "./BarList";
+export { default as BarList } from "./BarList";
+export type { BarListProps } from "./BarList";

--- a/src/components/vis-elements/CategoryBar/index.ts
+++ b/src/components/vis-elements/CategoryBar/index.ts
@@ -1,1 +1,2 @@
-export { default } from "./CategoryBar";
+export { default as CategoryBar } from "./CategoryBar";
+export type { CategoryBarProps } from "./CategoryBar";

--- a/src/components/vis-elements/DeltaBar/index.ts
+++ b/src/components/vis-elements/DeltaBar/index.ts
@@ -1,1 +1,2 @@
-export { default } from "./DeltaBar";
+export { default as DeltaBar } from "./DeltaBar";
+export type { DeltaBarProps } from "./DeltaBar";

--- a/src/components/vis-elements/MarkerBar/index.ts
+++ b/src/components/vis-elements/MarkerBar/index.ts
@@ -1,1 +1,2 @@
-export { default } from "./MarkerBar";
+export { default as MarkerBar } from "./MarkerBar";
+export type { MarkerBarProps } from "./MarkerBar";

--- a/src/components/vis-elements/ProgressBar/index.ts
+++ b/src/components/vis-elements/ProgressBar/index.ts
@@ -1,1 +1,2 @@
-export { default } from "./ProgressBar";
+export { default as ProgressBar } from "./ProgressBar";
+export type { ProgressBarProps } from "./ProgressBar";

--- a/src/components/vis-elements/RangeBar/index.ts
+++ b/src/components/vis-elements/RangeBar/index.ts
@@ -1,1 +1,2 @@
-export { default } from "./RangeBar";
+export { default as RangeBar } from "./RangeBar";
+export type { RangeBarProps } from "./RangeBar";

--- a/src/components/vis-elements/Tracker/index.ts
+++ b/src/components/vis-elements/Tracker/index.ts
@@ -1,1 +1,2 @@
-export { default } from "./Tracker";
+export { default as Tracker } from "./Tracker";
+export type { TrackerProps } from "./Tracker";

--- a/src/components/vis-elements/index.ts
+++ b/src/components/vis-elements/index.ts
@@ -1,7 +1,7 @@
-export { default as CategoryBar } from "./CategoryBar";
-export { default as DeltaBar } from "./DeltaBar";
-export { default as MarkerBar } from "./MarkerBar";
-export { default as ProgressBar } from "./ProgressBar";
-export { default as RangeBar } from "./RangeBar";
-export { default as BarList } from "./BarList";
-export { default as Tracker } from "./Tracker";
+export * from "./CategoryBar";
+export * from "./DeltaBar";
+export * from "./MarkerBar";
+export * from "./ProgressBar";
+export * from "./RangeBar";
+export * from "./BarList";
+export * from "./Tracker";

--- a/src/stories/layout-elements/Divider.stories.tsx
+++ b/src/stories/layout-elements/Divider.stories.tsx
@@ -1,9 +1,8 @@
 import React from "react";
 
 import { ComponentMeta, ComponentStory } from "@storybook/react";
-import Divider from "components/layout-elements/Divider/Divider";
 import { SimpleCard } from "stories/layout-elements/helpers/SimpleCard";
-import { Title } from "components";
+import { Divider, Title } from "components";
 
 // More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 export default {

--- a/src/stories/layout-elements/Flex.stories.tsx
+++ b/src/stories/layout-elements/Flex.stories.tsx
@@ -2,8 +2,7 @@ import React from "react";
 
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 
-import { Card, Metric } from "components";
-import Flex from "components/layout-elements/Flex/Flex";
+import { Card, Flex, Metric } from "components";
 import { SimpleCard } from "stories/layout-elements/helpers/SimpleCard";
 import { SimpleText } from "stories/layout-elements/helpers/SimpleText";
 

--- a/src/stories/list-elements/List.stories.tsx
+++ b/src/stories/list-elements/List.stories.tsx
@@ -1,8 +1,7 @@
 import React from "react";
 
 import { ComponentMeta, ComponentStory } from "@storybook/react";
-import List from "components/list-elements/List/List";
-import ListItem from "components/list-elements/List/ListItem";
+import { List, ListItem } from "components";
 
 // More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 export default {

--- a/src/stories/list-elements/Table.stories.tsx
+++ b/src/stories/list-elements/Table.stories.tsx
@@ -1,12 +1,17 @@
 import React from "react";
 
-import { Card, TableBody, TableHead, TableHeaderCell } from "components";
+import {
+  Card,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeaderCell,
+  TableRow,
+} from "components";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 
 import BadgeDelta from "components/icon-elements/BadgeDelta/BadgeDelta";
-import Table from "components/list-elements/Table/Table";
-import TableCell from "components/list-elements/Table/TableCell";
-import TableRow from "components/list-elements/Table/TableRow";
 import { DeltaType } from "lib";
 
 // More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export

--- a/src/stories/text-elements/Callout.stories.tsx
+++ b/src/stories/text-elements/Callout.stories.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { ArrowUpRightIcon } from "assets";
 
-import Callout from "../../components/text-elements/Callout/Callout";
+import { Callout } from "components";
 
 import { BaseColors } from "lib/constants";
 

--- a/src/stories/text-elements/Legend.stories.tsx
+++ b/src/stories/text-elements/Legend.stories.tsx
@@ -1,8 +1,7 @@
 import React from "react";
 
 import { ComponentMeta, ComponentStory } from "@storybook/react";
-import Card from "components/layout-elements/Card";
-import Legend from "components/text-elements/Legend/Legend";
+import { Card, Legend } from "components";
 
 // More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 export default {

--- a/src/stories/text-elements/Metric.stories.tsx
+++ b/src/stories/text-elements/Metric.stories.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { BaseColors } from "lib/constants";
-import Metric from "../../components/text-elements/Metric/Metric";
+import { Metric } from "components";
 
 // More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 export default {

--- a/src/stories/text-elements/Text.stories.tsx
+++ b/src/stories/text-elements/Text.stories.tsx
@@ -2,8 +2,7 @@ import React from "react";
 
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 
-import { Card } from "components";
-import Text from "components/text-elements/Text/Text";
+import { Card, Text } from "components";
 
 // More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 export default {

--- a/src/stories/text-elements/TextElements.stories.tsx
+++ b/src/stories/text-elements/TextElements.stories.tsx
@@ -2,11 +2,7 @@ import React from "react";
 
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 
-import Bold from "components/text-elements/Bold/Bold";
-import Italic from "components/text-elements/Italic/Italic";
-
-import Text from "components/text-elements/Text/Text";
-import Title from "components/text-elements/Title/Title";
+import { Bold, Italic, Text, Title } from "components";
 
 // More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 export default {

--- a/src/stories/text-elements/Title.stories.tsx
+++ b/src/stories/text-elements/Title.stories.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 import { ComponentMeta, ComponentStory } from "@storybook/react";
-import Title from "../../components/text-elements/Title/Title";
+import { Title } from "components";
 
 // More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 export default {

--- a/src/stories/vis-elements/CategoryBar.stories.tsx
+++ b/src/stories/vis-elements/CategoryBar.stories.tsx
@@ -3,8 +3,7 @@ import React from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import CategoryBar from "components/vis-elements/CategoryBar/CategoryBar";
 
-import Card from "components/layout-elements/Card";
-import Metric from "components/text-elements/Metric";
+import { Card, Metric } from "components";
 
 // More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 export default {

--- a/src/stories/vis-elements/DeltaBar.stories.tsx
+++ b/src/stories/vis-elements/DeltaBar.stories.tsx
@@ -1,9 +1,7 @@
 import React from "react";
 
 import { ComponentMeta, ComponentStory } from "@storybook/react";
-import Card from "components/layout-elements/Card";
-import DeltaBar from "components/vis-elements/DeltaBar/DeltaBar";
-import Metric from "components/text-elements/Metric";
+import { Card, DeltaBar, Metric } from "components";
 
 // More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 export default {

--- a/src/stories/vis-elements/MarkerBar.stories.tsx
+++ b/src/stories/vis-elements/MarkerBar.stories.tsx
@@ -1,10 +1,8 @@
 import React from "react";
 
 import { ComponentMeta, ComponentStory } from "@storybook/react";
-import MarkerBar from "components/vis-elements/MarkerBar/MarkerBar";
 
-import Card from "components/layout-elements/Card";
-import Metric from "components/text-elements/Metric";
+import { MarkerBar, Metric, Card } from "components";
 
 import { BaseColors } from "lib/constants";
 

--- a/src/stories/vis-elements/ProgressBar.stories.tsx
+++ b/src/stories/vis-elements/ProgressBar.stories.tsx
@@ -1,10 +1,8 @@
 import React from "react";
 
 import { ComponentMeta, ComponentStory } from "@storybook/react";
-import ProgressBar from "components/vis-elements/ProgressBar/ProgressBar";
 
-import Card from "components/layout-elements/Card";
-import Metric from "components/text-elements/Metric";
+import { Card, Metric, ProgressBar } from "components";
 
 import { BaseColors } from "lib/constants";
 import { Flex } from "components";

--- a/src/stories/vis-elements/RangeBar.stories.tsx
+++ b/src/stories/vis-elements/RangeBar.stories.tsx
@@ -3,8 +3,7 @@ import React from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import RangeBar from "components/vis-elements/RangeBar/RangeBar";
 
-import Card from "components/layout-elements/Card";
-import Metric from "components/text-elements/Metric";
+import { Card, Metric } from "components";
 
 import { BaseColors } from "lib/constants";
 

--- a/src/stories/vis-elements/Tracker.stories.tsx
+++ b/src/stories/vis-elements/Tracker.stories.tsx
@@ -2,9 +2,7 @@ import React from "react";
 
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 
-import { Card } from "components";
-
-import Tracker from "components/vis-elements/Tracker/Tracker";
+import { Card, Tracker } from "components";
 
 // More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 export default {

--- a/src/tests/icon-elements/Badge.test.tsx
+++ b/src/tests/icon-elements/Badge.test.tsx
@@ -2,7 +2,7 @@
 import React from "react";
 import { render } from "@testing-library/react";
 
-import Badge from "components/icon-elements/Badge";
+import Badge from "components/icon-elements/Badge/Badge";
 
 describe("Badge", () => {
   test("renders the Badge component with default props", () => {

--- a/src/tests/icon-elements/BadgeDelta.test.tsx
+++ b/src/tests/icon-elements/BadgeDelta.test.tsx
@@ -2,7 +2,7 @@
 import React from "react";
 import { render } from "@testing-library/react";
 
-import BadgeDelta from "components/icon-elements/BadgeDelta";
+import BadgeDelta from "components/icon-elements/BadgeDelta/BadgeDelta";
 
 describe("BadgeDelta", () => {
   test("renders the BadgeDelta component with default props", () => {

--- a/src/tests/icon-elements/Icon.test.tsx
+++ b/src/tests/icon-elements/Icon.test.tsx
@@ -4,7 +4,7 @@ import { render } from "@testing-library/react";
 
 import ArrowUpIcon from "assets/ArrowUpIcon";
 
-import Icon from "components/icon-elements/Icon";
+import Icon from "components/icon-elements/Icon/Icon";
 
 describe("Icon", () => {
   test("renders the Icon component with default props", () => {

--- a/src/tests/input-elements/Button.test.tsx
+++ b/src/tests/input-elements/Button.test.tsx
@@ -2,7 +2,7 @@
 import React from "react";
 import { render } from "@testing-library/react";
 
-import Button from "components/input-elements/Button";
+import Button from "components/input-elements/Button/Button";
 
 describe("Button", () => {
   test("renders the Button component with default props", () => {

--- a/src/tests/layout-elements/Card.test.tsx
+++ b/src/tests/layout-elements/Card.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { render } from "@testing-library/react";
 
-import Card from "components/layout-elements/Card";
+import Card from "components/layout-elements/Card/Card";
 
 describe("Card", () => {
   test("renders the Card component with default props", () => {

--- a/src/tests/layout-elements/Divider.test.tsx
+++ b/src/tests/layout-elements/Divider.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { render } from "@testing-library/react";
 
-import Divider from "components/layout-elements/Divider";
+import Divider from "components/layout-elements/Divider/Divider";
 
 describe("Divider", () => {
   test("renders the Divider component with default props", () => {

--- a/src/tests/layout-elements/Flex.test.tsx
+++ b/src/tests/layout-elements/Flex.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { render } from "@testing-library/react";
 
-import Flex from "components/layout-elements/Flex";
+import Flex from "components/layout-elements/Flex/Flex";
 
 describe("Flex", () => {
   test("renders the Flex component with default props", () => {

--- a/src/tests/layout-elements/Modal.test.tsx
+++ b/src/tests/layout-elements/Modal.test.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, useState } from "react";
 import { render } from "@testing-library/react";
 
-import Modal from "components/util-elements/Modal";
+import Modal from "components/util-elements/Modal/Modal";
 
 const TestModalWrapper = () => {
   const [showModal, setShowModal] = useState(false);

--- a/src/tests/text-elements/Callout.test.tsx
+++ b/src/tests/text-elements/Callout.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { render } from "@testing-library/react";
 
-import Callout from "components/text-elements/Callout";
+import Callout from "components/text-elements/Callout/Callout";
 
 describe("Callout", () => {
   test("renders the Callout component with default props", () => {

--- a/src/tests/text-elements/Legend.test.tsx
+++ b/src/tests/text-elements/Legend.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { render } from "@testing-library/react";
 
-import Legend from "components/text-elements/Legend";
+import Legend from "components/text-elements/Legend/Legend";
 
 describe("Legend", () => {
   test("renders the Legend component with default props", () => {

--- a/src/tests/text-elements/Metric.test.tsx
+++ b/src/tests/text-elements/Metric.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { render } from "@testing-library/react";
 
-import Metric from "components/text-elements/Metric";
+import Metric from "components/text-elements/Metric/Metric";
 
 describe("Metric", () => {
   test("renders the Metric component with default props", () => {

--- a/src/tests/text-elements/Subtitle.test.tsx
+++ b/src/tests/text-elements/Subtitle.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { render } from "@testing-library/react";
 
-import Subtitle from "components/text-elements/Subtitle";
+import Subtitle from "components/text-elements/Subtitle/Subtitle";
 
 describe("Subtitle", () => {
   test("renders the Subtitle component with default props", () => {

--- a/src/tests/text-elements/Text.test.tsx
+++ b/src/tests/text-elements/Text.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { render } from "@testing-library/react";
 
-import Text from "components/text-elements/Text";
+import Text from "components/text-elements/Text/Text";
 
 describe("Text", () => {
   test("renders the Text component with default props", () => {

--- a/src/tests/text-elements/Title.test.tsx
+++ b/src/tests/text-elements/Title.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { render } from "@testing-library/react";
 
-import Title from "components/text-elements/Title";
+import Title from "components/text-elements/Title/Title";
 
 describe("Title", () => {
   test("renders the Title component with default props", () => {

--- a/src/tests/vis-elements/BarList.test.tsx
+++ b/src/tests/vis-elements/BarList.test.tsx
@@ -2,7 +2,7 @@
 import React from "react";
 import { render } from "@testing-library/react";
 
-import BarList from "components/vis-elements/BarList";
+import BarList from "components/vis-elements/BarList/BarList";
 
 describe("BarList", () => {
   test("renders the BarList component with default props", () => {

--- a/src/tests/vis-elements/CategoryBar.test.tsx
+++ b/src/tests/vis-elements/CategoryBar.test.tsx
@@ -2,7 +2,7 @@
 import React from "react";
 import { render } from "@testing-library/react";
 
-import CategoryBar from "components/vis-elements/CategoryBar";
+import CategoryBar from "components/vis-elements/CategoryBar/CategoryBar";
 
 describe("CategoryBar", () => {
   test("renders the CategoryBar component with default props", () => {

--- a/src/tests/vis-elements/DeltaBar.test.tsx
+++ b/src/tests/vis-elements/DeltaBar.test.tsx
@@ -2,7 +2,7 @@
 import React from "react";
 import { render } from "@testing-library/react";
 
-import DeltaBar from "components/vis-elements/DeltaBar";
+import DeltaBar from "components/vis-elements/DeltaBar/DeltaBar";
 
 describe("DeltaBar", () => {
   test("renders the DeltaBar component with default props", () => {

--- a/src/tests/vis-elements/MarkerBar.test.tsx
+++ b/src/tests/vis-elements/MarkerBar.test.tsx
@@ -2,7 +2,7 @@
 import React from "react";
 import { render } from "@testing-library/react";
 
-import MarkerBar from "components/vis-elements/MarkerBar";
+import MarkerBar from "components/vis-elements/MarkerBar/MarkerBar";
 
 describe("MarkerBar", () => {
   test("renders the MarkerBar component with default props", () => {

--- a/src/tests/vis-elements/ProgressBar.test.tsx
+++ b/src/tests/vis-elements/ProgressBar.test.tsx
@@ -2,7 +2,7 @@
 import React from "react";
 import { render } from "@testing-library/react";
 
-import ProgressBar from "components/vis-elements/ProgressBar";
+import ProgressBar from "components/vis-elements/ProgressBar/ProgressBar";
 
 describe("ProgressBar", () => {
   test("renders the ProgressBar component with default props", () => {

--- a/src/tests/vis-elements/RangeBar.test.tsx
+++ b/src/tests/vis-elements/RangeBar.test.tsx
@@ -2,7 +2,7 @@
 import React from "react";
 import { render } from "@testing-library/react";
 
-import RangeBar from "components/vis-elements/RangeBar";
+import RangeBar from "components/vis-elements/RangeBar/RangeBar";
 
 describe("RangeBar", () => {
   test("renders the RangeBar component with default props", () => {


### PR DESCRIPTION
Closes: https://github.com/tremorlabs/tremor/issues/438#issue-1698714182

- Exported the props type of all your public components

I also did two other things along the way

- Fixed some inconsistencies in export syntax. Now in the index file of component folders (e.g. components/input-elements/Button/inex.ts) only named exports is used. Previously it was a mix of default and named exports. Also I just export * in the index file of group folders (e.g. components/input-elements/inex.ts). Previously it was a mix of export * and export { default as X }.

- Changed the extension of some files from tsx to ts because they didn't have anything related to React

I should've probably made multiple PRs for this; But the changes were very related and I was lazy. Sorry. I you are strict about this rule I can split it into multiple PRs.