### PR TITLE
fix: add `displayName` to anonymous components

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -21,7 +21,6 @@
       "@typescript-eslint/no-non-null-assertion": "off",
       "@typescript-eslint/ban-ts-comment": "off",
       "@typescript-eslint/no-explicit-any": "off",
-      "react/display-name": "off",
       "react/prop-types": "off"
     },
     "settings": {

--- a/src/components/chart-elements/AreaChart/AreaChart.tsx
+++ b/src/components/chart-elements/AreaChart/AreaChart.tsx
@@ -158,4 +158,6 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>((props, ref) 
   );
 });
 
+AreaChart.displayName = "AreaChart";
+
 export default AreaChart;

--- a/src/components/chart-elements/BarChart/BarChart.tsx
+++ b/src/components/chart-elements/BarChart/BarChart.tsx
@@ -179,4 +179,6 @@ const BarChart = React.forwardRef<HTMLDivElement, BarChartProps>((props, ref) =>
   );
 });
 
+BarChart.displayName = "BarChart";
+
 export default BarChart;

--- a/src/components/chart-elements/DonutChart/DonutChart.tsx
+++ b/src/components/chart-elements/DonutChart/DonutChart.tsx
@@ -89,4 +89,6 @@ const DonutChart = React.forwardRef<HTMLDivElement, DonutChartProps>((props, ref
   );
 });
 
+DonutChart.displayName = "DonutChart";
+
 export default DonutChart;

--- a/src/components/chart-elements/LineChart/LineChart.tsx
+++ b/src/components/chart-elements/LineChart/LineChart.tsx
@@ -133,4 +133,6 @@ const LineChart = React.forwardRef<HTMLDivElement, LineChartProps>((props, ref) 
   );
 });
 
+LineChart.displayName = "LineChart";
+
 export default LineChart;

--- a/src/components/icon-elements/Badge/Badge.tsx
+++ b/src/components/icon-elements/Badge/Badge.tsx
@@ -73,4 +73,6 @@ const Badge = React.forwardRef<HTMLSpanElement, BadgeProps>((props, ref) => {
   );
 });
 
+Badge.displayName = "Badge";
+
 export default Badge;

--- a/src/components/icon-elements/BadgeDelta/BadgeDelta.tsx
+++ b/src/components/icon-elements/BadgeDelta/BadgeDelta.tsx
@@ -67,4 +67,6 @@ const BadgeDelta = React.forwardRef<HTMLSpanElement, BadgeDeltaProps>((props, re
   );
 });
 
+BadgeDelta.displayName = "BadgeDelta";
+
 export default BadgeDelta;

--- a/src/components/icon-elements/Icon/Icon.tsx
+++ b/src/components/icon-elements/Icon/Icon.tsx
@@ -72,4 +72,6 @@ const Icon = React.forwardRef<HTMLSpanElement, IconProps>((props, ref) => {
   );
 });
 
+Icon.displayName = "Icon";
+
 export default Icon;

--- a/src/components/input-elements/Button/Button.tsx
+++ b/src/components/input-elements/Button/Button.tsx
@@ -164,4 +164,6 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => 
   );
 });
 
+Button.displayName = "Button";
+
 export default Button;

--- a/src/components/input-elements/DateRangePicker/DateRangePicker.tsx
+++ b/src/components/input-elements/DateRangePicker/DateRangePicker.tsx
@@ -207,4 +207,6 @@ const DateRangePicker = React.forwardRef<HTMLDivElement, DateRangePickerProps>((
   );
 });
 
+DateRangePicker.displayName = "DateRangePicker";
+
 export default DateRangePicker;

--- a/src/components/input-elements/Dropdown/Dropdown.tsx
+++ b/src/components/input-elements/Dropdown/Dropdown.tsx
@@ -149,4 +149,6 @@ const Dropdown = React.forwardRef<HTMLDivElement, DropdownProps>((props, ref) =>
   );
 });
 
+Dropdown.displayName = "Dropdown";
+
 export default Dropdown;

--- a/src/components/input-elements/Dropdown/DropdownItem.tsx
+++ b/src/components/input-elements/Dropdown/DropdownItem.tsx
@@ -73,4 +73,6 @@ const DropdownItem = React.forwardRef<HTMLButtonElement, DropdownItemProps>((pro
   );
 });
 
+DropdownItem.displayName = "DropdownItem";
+
 export default DropdownItem;

--- a/src/components/input-elements/MultiSelectBox/MultiSelectBox.tsx
+++ b/src/components/input-elements/MultiSelectBox/MultiSelectBox.tsx
@@ -246,4 +246,6 @@ const MultiSelectBox = React.forwardRef<HTMLDivElement, MultiSelectBoxProps>((pr
   );
 });
 
+MultiSelectBox.displayName = "MultiSelectBox";
+
 export default MultiSelectBox;

--- a/src/components/input-elements/MultiSelectBox/MultiSelectBoxItem.tsx
+++ b/src/components/input-elements/MultiSelectBox/MultiSelectBoxItem.tsx
@@ -91,4 +91,6 @@ const MultiSelectBoxItem = React.forwardRef<HTMLButtonElement, MultiSelectBoxIte
   },
 );
 
+MultiSelectBoxItem.displayName = "MultiSelectBoxItem";
+
 export default MultiSelectBoxItem;

--- a/src/components/input-elements/SelectBox/SelectBox.tsx
+++ b/src/components/input-elements/SelectBox/SelectBox.tsx
@@ -209,4 +209,6 @@ const SelectBox = React.forwardRef<HTMLDivElement, SelectBoxProps>((props, ref) 
   );
 });
 
+SelectBox.displayName = "SelectBox";
+
 export default SelectBox;

--- a/src/components/input-elements/SelectBox/SelectBoxItem.tsx
+++ b/src/components/input-elements/SelectBox/SelectBoxItem.tsx
@@ -79,4 +79,6 @@ const SelectBoxItem = React.forwardRef<HTMLButtonElement, SelectBoxItemProps>((p
   );
 });
 
+SelectBoxItem.displayName = "SelectBoxItem";
+
 export default SelectBoxItem;

--- a/src/components/input-elements/Tab/Tab.tsx
+++ b/src/components/input-elements/Tab/Tab.tsx
@@ -86,4 +86,6 @@ const Tab = React.forwardRef<HTMLButtonElement, TabProps>((props, ref) => {
   );
 });
 
+Tab.displayName = "Tab";
+
 export default Tab;

--- a/src/components/input-elements/Tab/TabList.tsx
+++ b/src/components/input-elements/Tab/TabList.tsx
@@ -59,4 +59,6 @@ const TabList = React.forwardRef<HTMLDivElement, TabListProps>((props, ref) => {
   );
 });
 
+TabList.displayName = "TabList";
+
 export default TabList;

--- a/src/components/input-elements/TextInput/TextInput.tsx
+++ b/src/components/input-elements/TextInput/TextInput.tsx
@@ -145,4 +145,6 @@ const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>((props, ref
   );
 });
 
+TextInput.displayName = "TextInput";
+
 export default TextInput;

--- a/src/components/input-elements/Toggle/Toggle.tsx
+++ b/src/components/input-elements/Toggle/Toggle.tsx
@@ -59,4 +59,6 @@ const Toggle = React.forwardRef<HTMLDivElement, ToggleProps>((props, ref) => {
   );
 });
 
+Toggle.displayName = "Toggle";
+
 export default Toggle;

--- a/src/components/input-elements/Toggle/ToggleItem.tsx
+++ b/src/components/input-elements/Toggle/ToggleItem.tsx
@@ -84,4 +84,6 @@ const ToggleItem = React.forwardRef<HTMLButtonElement, ToggleItemProps>((props, 
   );
 });
 
+ToggleItem.displayName = "ToggleItem";
+
 export default ToggleItem;

--- a/src/components/layout-elements/Accordion/Accordion.tsx
+++ b/src/components/layout-elements/Accordion/Accordion.tsx
@@ -55,4 +55,6 @@ const Accordion = React.forwardRef<HTMLDivElement, AccordionProps>((props, ref) 
   );
 });
 
+Accordion.displayName = "Accordion";
+
 export default Accordion;

--- a/src/components/layout-elements/Accordion/AccordionBody.tsx
+++ b/src/components/layout-elements/Accordion/AccordionBody.tsx
@@ -28,4 +28,6 @@ const AccordionBody = React.forwardRef<HTMLDivElement, AccordionBodyProps>((prop
   );
 });
 
+AccordionBody.displayName = "AccordionBody";
+
 export default AccordionBody;

--- a/src/components/layout-elements/Accordion/AccordionHeader.tsx
+++ b/src/components/layout-elements/Accordion/AccordionHeader.tsx
@@ -57,4 +57,6 @@ const AccordionHeader = React.forwardRef<HTMLButtonElement, AccordionHeaderProps
   );
 });
 
+AccordionHeader.displayName = "AccordionHeader";
+
 export default AccordionHeader;

--- a/src/components/layout-elements/Accordion/AccordionList.tsx
+++ b/src/components/layout-elements/Accordion/AccordionList.tsx
@@ -67,4 +67,6 @@ const AccordionList = React.forwardRef<HTMLDivElement, AccordionListProps>((prop
   );
 });
 
+AccordionList.displayName = "AccordionList";
+
 export default AccordionList;

--- a/src/components/layout-elements/Card/Card.tsx
+++ b/src/components/layout-elements/Card/Card.tsx
@@ -67,4 +67,6 @@ const Card = React.forwardRef<HTMLDivElement, CardProps>((props, ref) => {
   );
 });
 
+Card.displayName = "Card";
+
 export default Card;

--- a/src/components/layout-elements/Divider/Divider.tsx
+++ b/src/components/layout-elements/Divider/Divider.tsx
@@ -28,4 +28,6 @@ const Divider = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivEle
   },
 );
 
+Divider.displayName = "Divider";
+
 export default Divider;

--- a/src/components/layout-elements/Flex/Flex.tsx
+++ b/src/components/layout-elements/Flex/Flex.tsx
@@ -65,4 +65,6 @@ const Flex = React.forwardRef<HTMLDivElement, FlexProps>((props, ref) => {
   );
 });
 
+Flex.displayName = "Flex";
+
 export default Flex;

--- a/src/components/layout-elements/Grid/Col.tsx
+++ b/src/components/layout-elements/Grid/Col.tsx
@@ -52,4 +52,6 @@ const Col = React.forwardRef<HTMLDivElement, ColProps>((props, ref) => {
   );
 });
 
+Col.displayName = "Col";
+
 export default Col;

--- a/src/components/layout-elements/Grid/Grid.tsx
+++ b/src/components/layout-elements/Grid/Grid.tsx
@@ -46,4 +46,6 @@ const Grid = React.forwardRef<HTMLDivElement, GridProps>((props, ref) => {
   );
 });
 
+Grid.displayName = "Grid";
+
 export default Grid;

--- a/src/components/list-elements/List/List.tsx
+++ b/src/components/list-elements/List/List.tsx
@@ -27,4 +27,6 @@ const List = React.forwardRef<HTMLUListElement, React.HTMLAttributes<HTMLUListEl
   },
 );
 
+List.displayName = "List";
+
 export default List;

--- a/src/components/list-elements/List/ListItem.tsx
+++ b/src/components/list-elements/List/ListItem.tsx
@@ -28,4 +28,6 @@ const ListItem = React.forwardRef<HTMLLIElement, React.HTMLAttributes<HTMLLIElem
   },
 );
 
+ListItem.displayName = "ListItem";
+
 export default ListItem;

--- a/src/components/list-elements/Table/Table.tsx
+++ b/src/components/list-elements/Table/Table.tsx
@@ -30,4 +30,6 @@ const Table = React.forwardRef<HTMLTableElement, React.TableHTMLAttributes<HTMLT
   },
 );
 
+Table.displayName = "Table";
+
 export default Table;

--- a/src/components/list-elements/Table/TableBody.tsx
+++ b/src/components/list-elements/Table/TableBody.tsx
@@ -29,4 +29,6 @@ const TableBody = React.forwardRef<
   );
 });
 
+TableBody.displayName = "TableBody";
+
 export default TableBody;

--- a/src/components/list-elements/Table/TableCell.tsx
+++ b/src/components/list-elements/Table/TableCell.tsx
@@ -28,4 +28,6 @@ const TableCell = React.forwardRef<
   );
 });
 
+TableCell.displayName = "TableCell";
+
 export default TableCell;

--- a/src/components/list-elements/Table/TableHead.tsx
+++ b/src/components/list-elements/Table/TableHead.tsx
@@ -30,4 +30,6 @@ const TableHead = React.forwardRef<
   );
 });
 
+TableHead.displayName = "TableHead";
+
 export default TableHead;

--- a/src/components/list-elements/Table/TableHeaderCell.tsx
+++ b/src/components/list-elements/Table/TableHeaderCell.tsx
@@ -33,4 +33,6 @@ const TableHeaderCell = React.forwardRef<
   );
 });
 
+TableHeaderCell.displayName = "TableHeaderCell";
+
 export default TableHeaderCell;

--- a/src/components/list-elements/Table/TableRow.tsx
+++ b/src/components/list-elements/Table/TableRow.tsx
@@ -18,4 +18,6 @@ const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTML
   },
 );
 
+TableRow.displayName = "TableRow";
+
 export default TableRow;

--- a/src/components/text-elements/Bold/Bold.tsx
+++ b/src/components/text-elements/Bold/Bold.tsx
@@ -16,4 +16,6 @@ const Bold = React.forwardRef<HTMLElement, React.HTMLAttributes<HTMLElement>>((p
   );
 });
 
+Bold.displayName = "Bold";
+
 export default Bold;

--- a/src/components/text-elements/Callout/Callout.tsx
+++ b/src/components/text-elements/Callout/Callout.tsx
@@ -82,4 +82,6 @@ const Callout = React.forwardRef<HTMLDivElement, CalloutProps>((props, ref) => {
   );
 });
 
+Callout.displayName = "Callout";
+
 export default Callout;

--- a/src/components/text-elements/Italic/Italic.tsx
+++ b/src/components/text-elements/Italic/Italic.tsx
@@ -12,4 +12,6 @@ const Italic = React.forwardRef<HTMLElement, React.HTMLAttributes<HTMLElement>>(
   );
 });
 
+Italic.displayName = "Italic";
+
 export default Italic;

--- a/src/components/text-elements/Legend/Legend.tsx
+++ b/src/components/text-elements/Legend/Legend.tsx
@@ -72,4 +72,6 @@ const Legend = React.forwardRef<HTMLOListElement, LegendProps>((props, ref) => {
   );
 });
 
+Legend.displayName = "Legend";
+
 export default Legend;

--- a/src/components/text-elements/Metric/Metric.tsx
+++ b/src/components/text-elements/Metric/Metric.tsx
@@ -27,4 +27,6 @@ const Metric = React.forwardRef<HTMLParagraphElement, MetricProps>((props, ref) 
   );
 });
 
+Metric.displayName = "Metric";
+
 export default Metric;

--- a/src/components/text-elements/Subtitle/Subtitle.tsx
+++ b/src/components/text-elements/Subtitle/Subtitle.tsx
@@ -27,4 +27,6 @@ const Subtitle = React.forwardRef<HTMLParagraphElement, SubtitleProps>((props, r
   );
 });
 
+Subtitle.displayName = "Subtitle";
+
 export default Subtitle;

--- a/src/components/text-elements/Text/Text.tsx
+++ b/src/components/text-elements/Text/Text.tsx
@@ -26,4 +26,6 @@ const Text = React.forwardRef<HTMLParagraphElement, TextProps>((props, ref) => {
   );
 });
 
+Text.displayName = "Text";
+
 export default Text;

--- a/src/components/text-elements/Title/Title.tsx
+++ b/src/components/text-elements/Title/Title.tsx
@@ -27,4 +27,6 @@ const Title = React.forwardRef<HTMLParagraphElement, TitleProps>((props, ref) =>
   );
 });
 
+Title.displayName = "Title";
+
 export default Title;

--- a/src/components/util-elements/Modal/Modal.tsx
+++ b/src/components/util-elements/Modal/Modal.tsx
@@ -97,4 +97,6 @@ const Modal = React.forwardRef<HTMLDivElement, ModalProps>((props, ref) => {
   ) : null;
 });
 
+Modal.displayName = "Modal";
+
 export default Modal;

--- a/src/components/util-elements/Tooltip/Tooltip.tsx
+++ b/src/components/util-elements/Tooltip/Tooltip.tsx
@@ -90,4 +90,6 @@ const Tooltip = ({ text, open, x, y, refs, strategy, getFloatingProps }: Tooltip
   ) : null;
 };
 
+Tooltip.displayName = "Tooltip";
+
 export default Tooltip;

--- a/src/components/vis-elements/BarList/BarList.tsx
+++ b/src/components/vis-elements/BarList/BarList.tsx
@@ -162,4 +162,6 @@ const BarList = React.forwardRef<HTMLDivElement, BarListProps>((props, ref) => {
   );
 });
 
+BarList.displayName = "BarList";
+
 export default BarList;

--- a/src/components/vis-elements/CategoryBar/CategoryBar.tsx
+++ b/src/components/vis-elements/CategoryBar/CategoryBar.tsx
@@ -174,4 +174,6 @@ const CategoryBar = React.forwardRef<HTMLDivElement, CategoryBarProps>((props, r
   );
 });
 
+CategoryBar.displayName = "CategoryBar";
+
 export default CategoryBar;

--- a/src/components/vis-elements/DeltaBar/DeltaBar.tsx
+++ b/src/components/vis-elements/DeltaBar/DeltaBar.tsx
@@ -111,4 +111,6 @@ const DeltaBar = React.forwardRef<HTMLDivElement, DeltaBarProps>((props, ref) =>
   );
 });
 
+DeltaBar.displayName = "DeltaBar";
+
 export default DeltaBar;

--- a/src/components/vis-elements/MarkerBar/MarkerBar.tsx
+++ b/src/components/vis-elements/MarkerBar/MarkerBar.tsx
@@ -75,4 +75,6 @@ const MarkerBar = React.forwardRef<HTMLDivElement, MarkerBarProps>((props, ref) 
   );
 });
 
+MarkerBar.displayName = "MarkerBar";
+
 export default MarkerBar;

--- a/src/components/vis-elements/ProgressBar/ProgressBar.tsx
+++ b/src/components/vis-elements/ProgressBar/ProgressBar.tsx
@@ -99,4 +99,6 @@ const ProgressBar = React.forwardRef<HTMLDivElement, ProgressBarProps>((props, r
   );
 });
 
+ProgressBar.displayName = "ProgressBar";
+
 export default ProgressBar;

--- a/src/components/vis-elements/RangeBar/RangeBar.tsx
+++ b/src/components/vis-elements/RangeBar/RangeBar.tsx
@@ -95,4 +95,6 @@ const RangeBar = React.forwardRef<HTMLDivElement, RangeBarProps>((props, ref) =>
   );
 });
 
+RangeBar.displayName = "RangeBar";
+
 export default RangeBar;

--- a/src/components/vis-elements/Tracker/Tracker.tsx
+++ b/src/components/vis-elements/Tracker/Tracker.tsx
@@ -42,6 +42,8 @@ const TrackerBlock = React.forwardRef<HTMLDivElement, TrackerBlockProps>((props,
   );
 });
 
+TrackerBlock.displayName = "TrackerBlock";
+
 export interface TrackerProps extends React.HTMLAttributes<HTMLDivElement> {
   data: TrackerBlockProps[];
 }
@@ -65,5 +67,7 @@ const Tracker = React.forwardRef<HTMLDivElement, TrackerProps>((props, ref) => {
     </div>
   );
 });
+
+Tracker.displayName = "Tracker";
 
 export default Tracker;


### PR DESCRIPTION
Closes: https://github.com/tremorlabs/tremor/issues/445#issue-1706952817

- Added `displayName` to all anonymous components
- Enabled the eslint rule that forces specifying `displayName` for anonymous components. Previously, this was manually disabled