### PR TITLE
feat: Introduce onInputValueChange prop to SelectBox and MultiSelectBox components

### DIFF
--- a/src/components/input-elements/MultiSelectBox/MultiSelectBox.tsx
+++ b/src/components/input-elements/MultiSelectBox/MultiSelectBox.tsx
@@ -33,6 +33,7 @@ export interface MultiSelectBoxProps extends React.HTMLAttributes<HTMLDivElement
   defaultValue?: string[];
   value?: string[];
   onValueChange?: (value: string[]) => void;
+  onInputValueChange?: (value: string) => void;
   placeholder?: string;
   disabled?: boolean;
   icon?: React.ElementType | React.JSXElementConstructor<any>;
@@ -44,6 +45,7 @@ const MultiSelectBox = React.forwardRef<HTMLDivElement, MultiSelectBoxProps>((pr
     defaultValue,
     value,
     onValueChange,
+    onInputValueChange,
     placeholder = "Select...",
     disabled = false,
     icon,
@@ -85,6 +87,11 @@ const MultiSelectBox = React.forwardRef<HTMLDivElement, MultiSelectBoxProps>((pr
     }
     setSelectedValue(newSelectedItems);
     onValueChange?.(newSelectedItems);
+  };
+
+  const handleInputValueChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchQuery(e.target.value);
+    onInputValueChange?.(e.target.value);
   };
 
   const handleReset = () => {
@@ -224,7 +231,7 @@ const MultiSelectBox = React.forwardRef<HTMLDivElement, MultiSelectBoxProps>((pr
               fontSize.sm,
               fontWeight.md,
             )}
-            onChange={(e) => setSearchQuery(e.target.value)}
+            onChange={handleInputValueChange}
           />
         </div>
         <SelectedValueContext.Provider

--- a/src/components/input-elements/SelectBox/SelectBox.tsx
+++ b/src/components/input-elements/SelectBox/SelectBox.tsx
@@ -37,6 +37,7 @@ export interface SelectBoxProps extends React.HTMLAttributes<HTMLDivElement> {
   defaultValue?: string;
   value?: string;
   onValueChange?: (value: string) => void;
+  onInputValueChange?: (value: string) => void;
   placeholder?: string;
   disabled?: boolean;
   icon?: React.ElementType | React.JSXElementConstructor<any>;
@@ -48,6 +49,7 @@ const SelectBox = React.forwardRef<HTMLDivElement, SelectBoxProps>((props, ref) 
     defaultValue,
     value,
     onValueChange,
+    onInputValueChange,
     placeholder = "Select...",
     disabled = false,
     icon,
@@ -56,6 +58,7 @@ const SelectBox = React.forwardRef<HTMLDivElement, SelectBoxProps>((props, ref) 
     onKeyDown,
     ...other
   } = props;
+
   const valueToNameMapping = useMemo(() => constructValueToNameMapping(children), [children]);
 
   const [selectedValue, setSelectedValue] = useInternalState(defaultValue, value);
@@ -107,6 +110,8 @@ const SelectBox = React.forwardRef<HTMLDivElement, SelectBoxProps>((props, ref) 
   const handleInputValueChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setSearchQuery(e.target.value);
     setInputValue(e.target.value);
+
+    onInputValueChange?.(e.target.value);
   };
 
   const [hoveredValue, handleKeyDown] = useSelectOnKeyDown(


### PR DESCRIPTION
Closes #444 

**What** - This** PR exposes a new `onInputValueChange` prop to the `SelectBox` and `MultiSelectBox` components. As noted in the above issue, these components currently only have the `onValueChange` prop, which only fires when a menu item is selected. But, this prop does not fire when the user types into the search box, which prevents the developer from being able to capture user search input.

**Why** - Because of this missing prop, I was unable to use the `SelectBox` and `MultiSelectBox` in my application and had to create my own versions of these components as a workaround. In my application, there are tens of thousands of menu selection items, which cannot be loaded into the `SelectBox` all at once for performance reasons. I need to be able to listen to the user input so I can dynamically refresh the `SelectBox` menu options.

**How** - Mimicked the behavior of the `onValueChange` prop