### PR TITLE
feat: Add custom category name

### DIFF
--- a/src/components/chart-elements/AreaChart/AreaChart.tsx
+++ b/src/components/chart-elements/AreaChart/AreaChart.tsx
@@ -12,7 +12,7 @@ import {
 } from "recharts";
 import { AxisDomain } from "recharts/types/util/types";
 
-import { constructCategoryColors, getYAxisDomain } from "../common/utils";
+import { constructCategoryColors, getYAxisDomain, parseCategory } from "../common/utils";
 import BaseChartProps from "../common/BaseChartProps";
 import ChartLegend from "../common/ChartLegend";
 import ChartTooltip from "../common/ChartTooltip";
@@ -63,7 +63,10 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>((props, ref) 
     ...other
   } = props;
   const [legendHeight, setLegendHeight] = useState(60);
-  const categoryColors = constructCategoryColors(categories, colors);
+  const categoryColors = constructCategoryColors(
+    categories.map((category) => parseCategory(category).categoryKey),
+    colors,
+  );
 
   const yAxisDomain = getYAxisDomain(autoMinValue, minValue, maxValue);
 
@@ -154,17 +157,18 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>((props, ref) 
               />
             ) : null}
             {categories.map((category) => {
+              const { categoryKey } = parseCategory(category);
               return (
-                <defs key={category}>
+                <defs key={categoryKey}>
                   {showGradient ? (
                     <linearGradient
                       className={
                         getColorClassNames(
-                          categoryColors.get(category) ?? BaseColors.Gray,
+                          categoryColors.get(categoryKey) ?? BaseColors.Gray,
                           colorPalette.text,
                         ).textColor
                       }
-                      id={categoryColors.get(category)}
+                      id={categoryColors.get(categoryKey)}
                       x1="0"
                       y1="0"
                       x2="0"
@@ -177,11 +181,11 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>((props, ref) 
                     <linearGradient
                       className={
                         getColorClassNames(
-                          categoryColors.get(category) ?? BaseColors.Gray,
+                          categoryColors.get(categoryKey) ?? BaseColors.Gray,
                           colorPalette.text,
                         ).textColor
                       }
-                      id={categoryColors.get(category)}
+                      id={categoryColors.get(categoryKey)}
                       x1="0"
                       y1="0"
                       x2="0"
@@ -193,39 +197,42 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>((props, ref) 
                 </defs>
               );
             })}
-            {categories.map((category) => (
-              <Area
-                className={
-                  getColorClassNames(
-                    categoryColors.get(category) ?? BaseColors.Gray,
-                    colorPalette.text,
-                  ).strokeColor
-                }
-                activeDot={{
-                  className: tremorTwMerge(
-                    "stroke-tremor-background dark:stroke-dark-tremor-background",
+            {categories.map((category) => {
+              const { categoryKey, categoryName } = parseCategory(category);
+              return (
+                <Area
+                  className={
                     getColorClassNames(
-                      categoryColors.get(category) ?? BaseColors.Gray,
+                      categoryColors.get(categoryKey) ?? BaseColors.Gray,
                       colorPalette.text,
-                    ).fillColor,
-                  ),
-                }}
-                dot={false}
-                key={category}
-                name={category}
-                type={curveType}
-                dataKey={category}
-                stroke=""
-                fill={`url(#${categoryColors.get(category)})`}
-                strokeWidth={2}
-                strokeLinejoin="round"
-                strokeLinecap="round"
-                isAnimationActive={showAnimation}
-                animationDuration={animationDuration}
-                stackId={stack ? "a" : undefined}
-                connectNulls={connectNulls}
-              />
-            ))}
+                    ).strokeColor
+                  }
+                  activeDot={{
+                    className: tremorTwMerge(
+                      "stroke-tremor-background dark:stroke-dark-tremor-background",
+                      getColorClassNames(
+                        categoryColors.get(categoryKey) ?? BaseColors.Gray,
+                        colorPalette.text,
+                      ).fillColor,
+                    ),
+                  }}
+                  dot={false}
+                  key={categoryKey}
+                  name={categoryName}
+                  type={curveType}
+                  dataKey={categoryKey}
+                  stroke=""
+                  fill={`url(#${categoryColors.get(categoryKey)})`}
+                  strokeWidth={2}
+                  strokeLinejoin="round"
+                  strokeLinecap="round"
+                  isAnimationActive={showAnimation}
+                  animationDuration={animationDuration}
+                  stackId={stack ? "a" : undefined}
+                  connectNulls={connectNulls}
+                />
+              );
+            })}
           </ReChartsAreaChart>
         ) : (
           <NoData noDataText={noDataText} />

--- a/src/components/chart-elements/BarChart/BarChart.tsx
+++ b/src/components/chart-elements/BarChart/BarChart.tsx
@@ -14,7 +14,7 @@ import {
 } from "recharts";
 import { AxisDomain } from "recharts/types/util/types";
 
-import { constructCategoryColors, getYAxisDomain } from "../common/utils";
+import { constructCategoryColors, getYAxisDomain, parseCategory } from "../common/utils";
 import BaseChartProps from "../common/BaseChartProps";
 import ChartLegend from "../common/ChartLegend";
 import ChartTooltip from "../common/ChartTooltip";
@@ -56,7 +56,10 @@ const BarChart = React.forwardRef<HTMLDivElement, BarChartProps>((props, ref) =>
     ...other
   } = props;
   const [legendHeight, setLegendHeight] = useState(60);
-  const categoryColors = constructCategoryColors(categories, colors);
+  const categoryColors = constructCategoryColors(
+    categories.map((category) => parseCategory(category).categoryKey),
+    colors,
+  );
 
   const yAxisDomain = getYAxisDomain(autoMinValue, minValue, maxValue);
 
@@ -197,24 +200,27 @@ const BarChart = React.forwardRef<HTMLDivElement, BarChartProps>((props, ref) =>
                 content={({ payload }) => ChartLegend({ payload }, categoryColors, setLegendHeight)}
               />
             ) : null}
-            {categories.map((category) => (
-              <Bar
-                className={
-                  getColorClassNames(
-                    categoryColors.get(category) ?? BaseColors.Gray,
-                    colorPalette.background,
-                  ).fillColor
-                }
-                key={category}
-                name={category}
-                type="linear"
-                stackId={stack || relative ? "a" : undefined}
-                dataKey={category}
-                fill=""
-                isAnimationActive={showAnimation}
-                animationDuration={animationDuration}
-              />
-            ))}
+            {categories.map((category) => {
+              const { categoryKey, categoryName } = parseCategory(category);
+              return (
+                <Bar
+                  className={
+                    getColorClassNames(
+                      categoryColors.get(categoryKey) ?? BaseColors.Gray,
+                      colorPalette.background,
+                    ).fillColor
+                  }
+                  key={categoryKey}
+                  name={categoryName}
+                  type="linear"
+                  stackId={stack || relative ? "a" : undefined}
+                  dataKey={categoryKey}
+                  fill=""
+                  isAnimationActive={showAnimation}
+                  animationDuration={animationDuration}
+                />
+              );
+            })}
           </ReChartsBarChart>
         ) : (
           <NoData noDataText={noDataText} />

--- a/src/components/chart-elements/LineChart/LineChart.tsx
+++ b/src/components/chart-elements/LineChart/LineChart.tsx
@@ -12,7 +12,7 @@ import {
 } from "recharts";
 import { AxisDomain } from "recharts/types/util/types";
 
-import { constructCategoryColors, getYAxisDomain } from "../common/utils";
+import { constructCategoryColors, getYAxisDomain, parseCategory } from "../common/utils";
 import NoData from "../common/NoData";
 import BaseChartProps from "../common/BaseChartProps";
 import ChartLegend from "components/chart-elements/common/ChartLegend";
@@ -60,7 +60,10 @@ const LineChart = React.forwardRef<HTMLDivElement, LineChartProps>((props, ref) 
     ...other
   } = props;
   const [legendHeight, setLegendHeight] = useState(60);
-  const categoryColors = constructCategoryColors(categories, colors);
+  const categoryColors = constructCategoryColors(
+    categories.map((category) => parseCategory(category).categoryKey),
+    colors,
+  );
 
   const yAxisDomain = getYAxisDomain(autoMinValue, minValue, maxValue);
 
@@ -151,37 +154,40 @@ const LineChart = React.forwardRef<HTMLDivElement, LineChartProps>((props, ref) 
                 content={({ payload }) => ChartLegend({ payload }, categoryColors, setLegendHeight)}
               />
             ) : null}
-            {categories.map((category) => (
-              <Line
-                className={
-                  getColorClassNames(
-                    categoryColors.get(category) ?? BaseColors.Gray,
-                    colorPalette.text,
-                  ).strokeColor
-                }
-                activeDot={{
-                  className: tremorTwMerge(
-                    "stroke-tremor-background dark:stroke-dark-tremor-background",
+            {categories.map((category) => {
+              const { categoryKey, categoryName } = parseCategory(category);
+              return (
+                <Line
+                  className={
                     getColorClassNames(
-                      categoryColors.get(category) ?? BaseColors.Gray,
+                      categoryColors.get(categoryKey) ?? BaseColors.Gray,
                       colorPalette.text,
-                    ).fillColor,
-                  ),
-                }}
-                dot={false}
-                key={category}
-                name={category}
-                type={curveType}
-                dataKey={category}
-                stroke=""
-                strokeWidth={2}
-                strokeLinejoin="round"
-                strokeLinecap="round"
-                isAnimationActive={showAnimation}
-                animationDuration={animationDuration}
-                connectNulls={connectNulls}
-              />
-            ))}
+                    ).strokeColor
+                  }
+                  activeDot={{
+                    className: tremorTwMerge(
+                      "stroke-tremor-background dark:stroke-dark-tremor-background",
+                      getColorClassNames(
+                        categoryColors.get(categoryKey) ?? BaseColors.Gray,
+                        colorPalette.text,
+                      ).fillColor,
+                    ),
+                  }}
+                  dot={false}
+                  key={categoryKey}
+                  name={categoryName}
+                  type={curveType}
+                  dataKey={categoryKey}
+                  stroke=""
+                  strokeWidth={2}
+                  strokeLinejoin="round"
+                  strokeLinecap="round"
+                  isAnimationActive={showAnimation}
+                  animationDuration={animationDuration}
+                  connectNulls={connectNulls}
+                />
+              );
+            })}
           </ReChartsLineChart>
         ) : (
           <NoData noDataText={noDataText} />

--- a/src/components/chart-elements/common/BaseChartProps.tsx
+++ b/src/components/chart-elements/common/BaseChartProps.tsx
@@ -2,7 +2,7 @@ import { Color, ValueFormatter } from "../../../lib";
 import type BaseAnimationTimingProps from "./BaseAnimationTimingProps";
 interface BaseChartProps extends BaseAnimationTimingProps {
   data: any[];
-  categories: string[];
+  categories: string[] | { category: string; name: string }[];
   index: string;
   colors?: Color[];
   valueFormatter?: ValueFormatter;

--- a/src/components/chart-elements/common/ChartLegend.tsx
+++ b/src/components/chart-elements/common/ChartLegend.tsx
@@ -24,7 +24,7 @@ const ChartLegend = (
     <div ref={legendRef} className="flex items-center justify-end">
       <Legend
         categories={payload.map((entry: any) => entry.value)}
-        colors={payload.map((entry: any) => categoryColors.get(entry.value))}
+        colors={payload.map((entry: any) => categoryColors.get(entry.dataKey))}
       />
     </div>
   );

--- a/src/components/chart-elements/common/ChartTooltip.tsx
+++ b/src/components/chart-elements/common/ChartTooltip.tsx
@@ -116,14 +116,19 @@ const ChartTooltip = ({
         </div>
 
         <div className={tremorTwMerge(spacing.twoXl.paddingX, spacing.sm.paddingY, "space-y-1")}>
-          {payload.map(({ value, name }: { value: number; name: string }, idx: number) => (
-            <ChartTooltipRow
-              key={`id-${idx}`}
-              value={valueFormatter(value)}
-              name={name}
-              color={categoryColors.get(name) ?? BaseColors.Blue}
-            />
-          ))}
+          {payload.map(
+            (
+              { value, name, dataKey }: { value: number; name: string; dataKey: string },
+              idx: number,
+            ) => (
+              <ChartTooltipRow
+                key={`id-${idx}`}
+                value={valueFormatter(value)}
+                name={name}
+                color={categoryColors.get(dataKey) ?? BaseColors.Blue}
+              />
+            ),
+          )}
         </div>
       </ChartTooltipFrame>
     );

--- a/src/components/chart-elements/common/utils.ts
+++ b/src/components/chart-elements/common/utils.ts
@@ -20,3 +20,10 @@ export const getYAxisDomain = (
   const maxDomain = maxValue ?? "auto";
   return [minDomain, maxDomain];
 };
+
+export const parseCategory = (category: string | { category: string; name: string }) => {
+  return {
+    categoryKey: typeof category === "object" ? category.category : category,
+    categoryName: typeof category === "object" ? category.name : category,
+  };
+};

--- a/src/stories/chart-elements/AreaChart.stories.tsx
+++ b/src/stories/chart-elements/AreaChart.stories.tsx
@@ -200,3 +200,18 @@ WithShortAnimationDuration.args = {
   categories: ["Sales", "Successful Payments"],
   index: "month",
 };
+
+export const WithCategoriesWithCustomNames = DefaultTemplate.bind({});
+WithCategoriesWithCustomNames.args = {
+  data,
+  categories: [
+    {
+      category: "Sales",
+      name: "Sales Completed",
+    },
+    {
+      category: "Successful Payments",
+      name: "Payments Completed",
+    },
+  ],
+};

--- a/src/stories/chart-elements/BarChart.stories.tsx
+++ b/src/stories/chart-elements/BarChart.stories.tsx
@@ -197,3 +197,18 @@ WithShortAnimationDuration.args = {
   categories: ["Sales", "Successful Payments"],
   index: "month",
 };
+
+export const WithCategoriesWithCustomNames = DefaultTemplate.bind({});
+WithCategoriesWithCustomNames.args = {
+  data,
+  categories: [
+    {
+      category: "Sales",
+      name: "Sales Completed",
+    },
+    {
+      category: "Successful Payments",
+      name: "Payments Completed",
+    },
+  ],
+};

--- a/src/stories/chart-elements/LineChart.stories.tsx
+++ b/src/stories/chart-elements/LineChart.stories.tsx
@@ -186,3 +186,18 @@ WithShortAnimationDuration.args = {
   categories: ["Sales", "Successful Payments"],
   index: "month",
 };
+
+export const WithCategoriesWithCustomNames = DefaultTemplate.bind({});
+WithCategoriesWithCustomNames.args = {
+  data,
+  categories: [
+    {
+      category: "Sales",
+      name: "Sales Completed",
+    },
+    {
+      category: "Successful Payments",
+      name: "Payments Completed",
+    },
+  ],
+};


### PR DESCRIPTION
Fixes #419 

What - Add the possibility to customize the name displayed for each category

Why - Because it is currently not possible to submit an alias

How - adding support so that the categories prop can receive an array of objects in this format:
`categories: string[] | { category: string; name: string }[]`; . `name` is the name to be displayed on the screen and the category is the main key of the category

Testing - you can see the changes by running the storybook(npm run storybook) and choosing the "With Categories With Custom Names" version, on every chart except the DonutChart

## Demo
https://www.loom.com/share/8abb8e88cca343508dc539a705898b55

---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.