### PR TITLE
fix: removed xcircle when no option is selected in MultiSelect

### DIFF
--- a/src/components/input-elements/DateRangePicker/DateRangePicker.tsx
+++ b/src/components/input-elements/DateRangePicker/DateRangePicker.tsx
@@ -192,15 +192,10 @@ const DateRangePicker = React.forwardRef<HTMLDivElement, DateRangePickerProps>((
           >
             {formattedSelection}
           </Popover.Button>
-          {isClearEnabled && (
+          {isClearEnabled && selectedStartDate ? (
             <button
               className={tremorTwMerge(
-                // common
-                "absolute outline-none focus:ring-2 inset-y-0 right-0 flex items-center transition duration-100",
-                // light
-                "focus:border-tremor-brand-subtle focus:ring-tremor-brand-muted",
-                // dark
-                "dark:focus:border-dark-tremor-brand-subtle dark:focus:ring-dark-tremor-brand-muted",
+                "absolute outline-none inset-y-0 right-0 flex items-center transition duration-100",
                 spacing.twoXl.marginRight,
               )}
               onClick={(e) => {
@@ -222,7 +217,7 @@ const DateRangePicker = React.forwardRef<HTMLDivElement, DateRangePickerProps>((
                 )}
               />
             </button>
-          )}
+          ) : null}
         </div>
         <Popover.Panel
           className={tremorTwMerge(

--- a/src/components/input-elements/MultiSelect/MultiSelect.tsx
+++ b/src/components/input-elements/MultiSelect/MultiSelect.tsx
@@ -42,6 +42,9 @@ const MultiSelect = React.forwardRef<HTMLDivElement, MultiSelectProps>((props, r
   const [selectedValue, setSelectedValue] = useInternalState(defaultValue, value);
   const [searchQuery, setSearchQuery] = useState("");
 
+  const selectedItems = selectedValue ?? [];
+  const hasSelection = selectedItems.length > 0;
+
   const filteredOptions = useMemo(
     () => getFilteredOptions(searchQuery, children as React.ReactElement[]),
     [searchQuery, children],
@@ -134,30 +137,34 @@ const MultiSelect = React.forwardRef<HTMLDivElement, MultiSelectProps>((props, r
               />
             </span>
           </Listbox.Button>
-          <button
-            className={tremorTwMerge(
-              "absolute inset-y-0 right-0 flex items-center",
-              spacing.fourXl.marginRight,
-            )}
-            onClick={(e) => {
-              e.preventDefault();
-              handleReset();
-            }}
-          >
-            <XCircleIcon
+
+          {hasSelection && !disabled ? (
+            <button
               className={tremorTwMerge(
-                makeMultiSelectClassName("clearIcon"),
-                // common
-                "flex-none",
-                // light
-                "text-tremor-content-subtle",
-                // dark
-                "dark:text-dark-tremor-content-subtle",
-                sizing.md.height,
-                sizing.md.width,
+                "absolute inset-y-0 right-0 flex items-center",
+                spacing.fourXl.marginRight,
               )}
-            />
-          </button>
+              onClick={(e) => {
+                e.preventDefault();
+                handleReset();
+              }}
+            >
+              <XCircleIcon
+                className={tremorTwMerge(
+                  makeMultiSelectClassName("clearIcon"),
+                  // common
+                  "flex-none",
+                  // light
+                  "text-tremor-content-subtle",
+                  // dark
+                  "dark:text-dark-tremor-content-subtle",
+                  sizing.md.height,
+                  sizing.md.width,
+                )}
+              />
+            </button>
+          ) : null}
+
           <Listbox.Options
             className={tremorTwMerge(
               // common

--- a/src/components/input-elements/MultiSelect/MultiSelect.tsx
+++ b/src/components/input-elements/MultiSelect/MultiSelect.tsx
@@ -42,6 +42,8 @@ const MultiSelect = React.forwardRef<HTMLDivElement, MultiSelectProps>((props, r
   const [selectedValue, setSelectedValue] = useInternalState(defaultValue, value);
   const [searchQuery, setSearchQuery] = useState("");
 
+  // checked if there are selected options
+  // used the same code from the previous version
   const selectedItems = selectedValue ?? [];
   const hasSelection = selectedItems.length > 0;
 
@@ -138,6 +140,7 @@ const MultiSelect = React.forwardRef<HTMLDivElement, MultiSelectProps>((props, r
             </span>
           </Listbox.Button>
 
+          {/* coditionally showed XCircle */}
           {hasSelection && !disabled ? (
             <button
               className={tremorTwMerge(


### PR DESCRIPTION
**Description**

<!--- Describe your changes in detail -->

**Related issue(s)**
https://github.com/tremorlabs/tremor/issues/523

*** Steps to reproduce ***
- in MultiSelect component, there is already a cross icon at the right of select even though no option is selected
- so, I show that conditionally (only when one or more options are selected)

**What kind of change does this PR introduce?** (check at least one)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**How has This been tested?**
I already tested the result in the storybook MultiSelect component. Circle is correctly removed when no option selected.

**Screenshots (if appropriate):**
Before fixing
[Before](https://ibb.co/FgYVphK)

After fixing
[After](https://ibb.co/cbRf4rZ)

**The PR fulfills these requirements:**

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It's submitted to the `main` branch
- [x] When resolving a specific issue, it's referenced in the related issue section above
- [ ] My change requires a change to the documentation. (Managed by Tremor Team)
- [ ] I have added tests to cover my changes
- [x] Check the ["Allow edits from maintainers" option](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) while creating your PR.
- [x] Add refs #XXX or fixes #XXX to the related issue section if your PR refers to or fixes an issue.
