### PR TITLE
fix: safari svg arrow display

### DIFF
--- a/src/assets/ArrowLeftHeadIcon.tsx
+++ b/src/assets/ArrowLeftHeadIcon.tsx
@@ -2,13 +2,12 @@ import React from "react";
 
 const ArrowLeftHeadIcon = ({ ...props }) => (
   <svg
-    {...props}
-    className="h-4 w-4"
     xmlns="http://www.w3.org/2000/svg"
     fill="none"
     viewBox="0 0 24 24"
     stroke="currentColor"
     strokeWidth="2.5"
+    {...props}
   >
     <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
   </svg>

--- a/src/assets/ArrowLeftHeadIcon.tsx
+++ b/src/assets/ArrowLeftHeadIcon.tsx
@@ -1,9 +1,9 @@
-/* eslint-disable max-len */
 import React from "react";
 
 const ArrowLeftHeadIcon = ({ ...props }) => (
   <svg
     {...props}
+    className="h-4 w-4"
     xmlns="http://www.w3.org/2000/svg"
     fill="none"
     viewBox="0 0 24 24"

--- a/src/assets/ArrowRightHeadIcon.tsx
+++ b/src/assets/ArrowRightHeadIcon.tsx
@@ -1,9 +1,9 @@
-/* eslint-disable max-len */
 import React from "react";
 
 const ArrowRightHeadIcon = ({ ...props }) => (
   <svg
     {...props}
+    className="h-4 w-4"
     xmlns="http://www.w3.org/2000/svg"
     fill="none"
     viewBox="0 0 24 24"

--- a/src/assets/ArrowRightHeadIcon.tsx
+++ b/src/assets/ArrowRightHeadIcon.tsx
@@ -2,13 +2,12 @@ import React from "react";
 
 const ArrowRightHeadIcon = ({ ...props }) => (
   <svg
-    {...props}
-    className="h-4 w-4"
     xmlns="http://www.w3.org/2000/svg"
     fill="none"
     viewBox="0 0 24 24"
     stroke="currentColor"
     strokeWidth="2.5"
+    {...props}
   >
     <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
   </svg>

--- a/src/components/input-elements/DateRangePicker/DateRangePicker.tsx
+++ b/src/components/input-elements/DateRangePicker/DateRangePicker.tsx
@@ -227,7 +227,7 @@ const DateRangePicker = React.forwardRef<HTMLDivElement, DateRangePickerProps>((
         <Popover.Panel
           className={tremorTwMerge(
             // common
-            "absolute z-10 divide-y overflow-y-auto min-w-min left-0 outline-none rounded-tremor-default",
+            "absolute z-10 divide-y overflow-y-auto min-w-min left-0 outline-none rounded-tremor-default p-3",
             // light
             "bg-tremor-background border-tremor-border divide-tremor-border shadow-tremor-dropdown",
             // dark
@@ -253,7 +253,6 @@ const DateRangePicker = React.forwardRef<HTMLDivElement, DateRangePickerProps>((
             }
             locale={locale}
             disabled={disabledDays}
-            className="p-3"
             classNames={{
               months: "flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0",
               month: "space-y-4",
@@ -287,8 +286,8 @@ const DateRangePicker = React.forwardRef<HTMLDivElement, DateRangePickerProps>((
                 "rounded-l-none rounded-r-tremor-small aria-selected:text-tremor-brand-inverted dark:aria-selected:text-dark-tremor-brand-inverted",
             }}
             components={{
-              IconLeft: ({ ...props }) => <ArrowLeftHeadIcon className="h-4 w-4" {...props} />,
-              IconRight: ({ ...props }) => <ArrowRightHeadIcon className="h-4 w-4" {...props} />,
+              IconLeft: ({ ...props }) => <ArrowLeftHeadIcon {...props} />,
+              IconRight: ({ ...props }) => <ArrowRightHeadIcon {...props} />,
             }}
             {...props}
           />

--- a/src/components/input-elements/DateRangePicker/DateRangePicker.tsx
+++ b/src/components/input-elements/DateRangePicker/DateRangePicker.tsx
@@ -286,8 +286,8 @@ const DateRangePicker = React.forwardRef<HTMLDivElement, DateRangePickerProps>((
                 "rounded-l-none rounded-r-tremor-small aria-selected:text-tremor-brand-inverted dark:aria-selected:text-dark-tremor-brand-inverted",
             }}
             components={{
-              IconLeft: ({ ...props }) => <ArrowLeftHeadIcon {...props} />,
-              IconRight: ({ ...props }) => <ArrowRightHeadIcon {...props} />,
+              IconLeft: ({ ...props }) => <ArrowLeftHeadIcon {...props} className="h-4 w-4" />,
+              IconRight: ({ ...props }) => <ArrowRightHeadIcon {...props} className="h-4 w-4" />,
             }}
             {...props}
           />


### PR DESCRIPTION
<!--
Please make sure to read the Contribution Guidelines:
https://github.com/tremorlabs/tremor/blob/main/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
**Description**

This PR fixes a Date Range Picker error in Safari. The arrows of the month selection were not displayed.

**Related issue(s)**

**What kind of change does this PR introduce?** (check at least one)
<!-- (Update "[ ]" to "[x]" to check a box) -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**How has This been tested?**

Storybook

**Screenshots (if appropriate):**


**The PR fulfills these requirements:**

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the related issue section above
- [ ] My change requires a change to the documentation. (Managed by Tremor Team)
- [ ] I have added tests to cover my changes
- [ ] Check the ["Allow edits from maintainers" option](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) while creating your PR.
- [ ] Add refs #XXX or fixes #XXX to the related issue section if your PR refers to or fixes an issue.
