### PR TITLE
feat: add monotone to CurveType

### DIFF
--- a/src/lib/inputTypes.ts
+++ b/src/lib/inputTypes.ts
@@ -2,7 +2,7 @@ export type ValueFormatter = {
   (value: number): string;
 };
 
-export type CurveType = "linear" | "natural" | "step";
+export type CurveType = "linear" | "natural" | "monotone" | "step";
 
 const iconVariantValues = ["simple", "light", "shadow", "solid", "outlined"] as const;
 


### PR DESCRIPTION
**Description**
- Natural curve type for Area and Line charts over/under represents values
- Recharts has "Monotone" curve type available
- This PR adds "monotone" to CurveType

**Related issue(s)**
Fixes #560 

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**How has This been tested?**
In Storybook for Area and Line. Monotone value available on curveType.

**Screenshots (if appropriate):**


**The PR fulfills these requirements:**

- [x] It's submitted to the `main` branch
- [x] When resolving a specific issue, it's referenced in the related issue section above
- [x] My change requires a change to the documentation. (Managed by Tremor Team)
- [ ] I have added tests to cover my changes
- [x] Check the ["Allow edits from maintainers" option](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) while creating your PR.
- [x] Add refs #XXX or fixes #XXX to the related issue section if your PR refers to or fixes an issue.
