### PR TITLE
fix: ScatterChart XAxis color

### DIFF
--- a/src/components/chart-elements/ScatterChart/ScatterChart.tsx
+++ b/src/components/chart-elements/ScatterChart/ScatterChart.tsx
@@ -137,8 +137,8 @@ const ScatterChart = React.forwardRef<HTMLDivElement, ScatterChartProps>((props,
                 ticks={startEndOnly ? [data[0][x], data[data.length - 1][x]] : undefined}
                 type="number"
                 name={x}
-                // fill=""
-                // stroke=""
+                fill=""
+                stroke=""
                 className={tremorTwMerge(
                   // common
                   "text-tremor-label",


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
**Description**

Removed the comments of the stroke and fill properties of the XAxis. This change was necessary because the previous implementation restricted the ability to modify the text color of the axis

**Related issue(s)**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**How has This been tested?**

Changing the content defaut color in the config Tailwind file

**The PR fulfills these requirements:**

- [x] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the related issue section above
- [ ] My change requires a change to the documentation. (Managed by Tremor Team)
- [ ] I have added tests to cover my changes
- [ ] Check the ["Allow edits from maintainers" option](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) while creating your PR.
- [ ] Add refs #XXX or fixes #XXX to the related issue section if your PR refers to or fixes an issue.
