### PR TITLE
fix: DatePickerValue is not defined and exported

### DIFF
--- a/src/components/input-elements/DatePicker/DatePicker.tsx
+++ b/src/components/input-elements/DatePicker/DatePicker.tsx
@@ -18,11 +18,13 @@ const TODAY = startOfToday();
 
 export type Locale = typeof enUS;
 
+export type DatePickerValue = Date | undefined;
+
 export interface DatePickerProps
   extends Omit<React.HTMLAttributes<HTMLDivElement>, "value" | "defaultValue"> {
   value?: Date;
   defaultValue?: Date;
-  onValueChange?: (value: Date | undefined) => void;
+  onValueChange?: (value: DatePickerValue) => void;
   minDate?: Date;
   maxDate?: Date;
   placeholder?: string;

--- a/src/components/input-elements/DatePicker/index.ts
+++ b/src/components/input-elements/DatePicker/index.ts
@@ -1,2 +1,2 @@
 export { default as DatePicker } from "./DatePicker";
-export type { DatePickerProps } from "./DatePicker";
+export type { DatePickerProps, DatePickerValue } from "./DatePicker";


### PR DESCRIPTION
<!--
Please make sure to read the Contribution Guidelines:
https://github.com/tremorlabs/tremor/blob/main/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
**Description**

This PR fixes a bug where attempting to compile TypeScript code that imported `DatePickerValue` threw an error. Although `DatePickerValue` is shown in the official documentation, it is not defined and exported in Tremor. 

**Related issue(s)**
Fixes #610 

**What kind of change does this PR introduce?** (check at least one)
<!-- (Update "[ ]" to "[x]" to check a box) -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**How has This been tested?**

I attempted to import `DatePickerValue` using the example given in the official documentation and retrieve its state in my code. The TypeScript compiler gave an error when building the code. Defining `DatePickerValue` as a type of `Date | undefined` allowed my code to compile successfully.
<!--- Please describe how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Screenshots (if appropriate):**


**The PR fulfills these requirements:**

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It's submitted to the `main` branch
- [x] When resolving a specific issue, it's referenced in the related issue section above
- [ ] My change requires a change to the documentation. (Managed by Tremor Team)
- [ ] I have added tests to cover my changes
- [x] Check the ["Allow edits from maintainers" option](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) while creating your PR.
- [x] Add refs #XXX or fixes #XXX to the related issue section if your PR refers to or fixes an issue.
