### PR TITLE
feat: Show/hide value in text input password

### DIFF
--- a/src/assets/ArrowDownHeadIcon.tsx
+++ b/src/assets/ArrowDownHeadIcon.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import React from "react";
 
 const ArrowDownHeadIcon = ({ ...props }) => (

--- a/src/assets/ArrowDownIcon.tsx
+++ b/src/assets/ArrowDownIcon.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import React from "react";
 
 const ArrowDownIcon = ({ ...props }) => (

--- a/src/assets/ArrowDownRightIcon.tsx
+++ b/src/assets/ArrowDownRightIcon.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import React from "react";
 
 const ArrowDownRightIcon = ({ ...props }) => (

--- a/src/assets/ArrowUpHeadIcon.tsx
+++ b/src/assets/ArrowUpHeadIcon.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import React from "react";
 
 const ArrowUpHeadIcon = ({ ...props }) => (

--- a/src/assets/ArrowUpIcon.tsx
+++ b/src/assets/ArrowUpIcon.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import React from "react";
 
 const ArrowUpIcon = ({ ...props }) => (

--- a/src/assets/ArrowUpRightIcon.tsx
+++ b/src/assets/ArrowUpRightIcon.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import React from "react";
 
 const ArrowUpRightIcon = ({ ...props }) => (

--- a/src/assets/CalendarIcon.tsx
+++ b/src/assets/CalendarIcon.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import React from "react";
 
 const CalendarIcon = ({ ...props }) => (

--- a/src/assets/DoubleArrowLeftHeadIcon.tsx
+++ b/src/assets/DoubleArrowLeftHeadIcon.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import React from "react";
 
 const DoubleArrowLeftHeadIcon = ({ ...props }) => (

--- a/src/assets/DoubleArrowRightHeadIcon.tsx
+++ b/src/assets/DoubleArrowRightHeadIcon.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import React from "react";
 
 const DoubleArrowRightHeadIcon = ({ ...props }) => (

--- a/src/assets/ExclamationFilledIcon.tsx
+++ b/src/assets/ExclamationFilledIcon.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import React from "react";
 
 const ExclamationFilledIcon = ({ ...props }) => (

--- a/src/assets/EyeIcon.tsx
+++ b/src/assets/EyeIcon.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+
+const EyeIcon = ({ ...props }) => (
+  <svg
+    {...props}
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth="1.5"
+    stroke="currentColor"
+    className="w-6 h-6"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z"
+    />
+    <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+  </svg>
+);
+
+export default EyeIcon;

--- a/src/assets/EyeIcon.tsx
+++ b/src/assets/EyeIcon.tsx
@@ -8,7 +8,6 @@ const EyeIcon = ({ ...props }) => (
     viewBox="0 0 24 24"
     strokeWidth="1.5"
     stroke="currentColor"
-    className="w-6 h-6"
   >
     <path
       strokeLinecap="round"

--- a/src/assets/EyeOffIcon.tsx
+++ b/src/assets/EyeOffIcon.tsx
@@ -8,7 +8,6 @@ const EyeOffIcon = ({ ...props }) => (
     viewBox="0 0 24 24"
     strokeWidth="1.5"
     stroke="currentColor"
-    className="w-6 h-6"
   >
     <path
       strokeLinecap="round"

--- a/src/assets/EyeOffIcon.tsx
+++ b/src/assets/EyeOffIcon.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+
+const EyeOffIcon = ({ ...props }) => (
+  <svg
+    {...props}
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth="1.5"
+    stroke="currentColor"
+    className="w-6 h-6"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M3.98 8.223A10.477 10.477 0 001.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.45 10.45 0 0112 4.5c4.756 0 8.773 3.162 10.065 7.498a10.523 10.523 0 01-4.293 5.774M6.228 6.228L3 3m3.228 3.228l3.65 3.65m7.894 7.894L21 21m-3.228-3.228l-3.65-3.65m0 0a3 3 0 10-4.243-4.243m4.242 4.242L9.88 9.88"
+    />
+  </svg>
+);
+
+export default EyeOffIcon;

--- a/src/assets/LoadingSpinner.tsx
+++ b/src/assets/LoadingSpinner.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import React from "react";
 
 const LoadingSpinner = ({ ...props }) => (

--- a/src/assets/MinusIcon.tsx
+++ b/src/assets/MinusIcon.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import React from "react";
 
 const MinusIcon = ({ ...props }) => (

--- a/src/assets/PlusIcon.tsx
+++ b/src/assets/PlusIcon.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import React from "react";
 
 const PlusIcon = ({ ...props }) => (

--- a/src/assets/SearchIcon.tsx
+++ b/src/assets/SearchIcon.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import React from "react";
 
 const SearchIcon = ({ ...props }) => (

--- a/src/assets/index.ts
+++ b/src/assets/index.ts
@@ -16,3 +16,5 @@ export { default as SearchIcon } from "./SearchIcon";
 export { default as XCircleIcon } from "./XCircleIcon";
 export { default as PlusIcon } from "./PlusIcon";
 export { default as MinusIcon } from "./MinusIcon";
+export { default as EyeIcon } from "./EyeIcon";
+export { default as EyeOffIcon } from "./EyeOffIcon";

--- a/src/components/input-elements/BaseInput.tsx
+++ b/src/components/input-elements/BaseInput.tsx
@@ -1,8 +1,9 @@
 "use client";
-import React, { ReactNode, useRef, useState } from "react";
+import React, { ReactNode, useCallback, useRef, useState } from "react";
 import { border, mergeRefs, sizing, spacing, tremorTwMerge } from "lib";
-import { ExclamationFilledIcon } from "assets";
+import { ExclamationFilledIcon, EyeIcon, EyeOffIcon } from "assets";
 import { getSelectButtonColors, hasValue } from "components/input-elements/selectUtils";
+import { Icon as IconComponent } from "components/icon-elements";
 
 export interface BaseInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   type?: "text" | "password" | "email" | "url" | "number";
@@ -32,6 +33,12 @@ const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>((props, ref
     ...other
   } = props;
   const [isFocused, setIsFocused] = useState(false);
+  const [isPasswordVisible, setIsPasswordVisible] = useState(false);
+
+  const toggleIsPasswordVisible = useCallback(
+    () => setIsPasswordVisible(!isPasswordVisible),
+    [isPasswordVisible, setIsPasswordVisible],
+  );
 
   const Icon = icon;
 
@@ -104,7 +111,7 @@ const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>((props, ref
           ref={mergeRefs([inputRef, ref])}
           defaultValue={defaultValue}
           value={value}
-          type={type}
+          type={isPasswordVisible ? "text" : type}
           className={tremorTwMerge(
             makeInputClassName("input"),
             // common
@@ -126,6 +133,19 @@ const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>((props, ref
           data-testid="base-input"
           {...other}
         />
+        {type === "password" && (
+          <button
+            className={tremorTwMerge(makeInputClassName("toggleButton"), "mr-2")}
+            type="button"
+            onClick={() => toggleIsPasswordVisible()}
+          >
+            {isPasswordVisible ? (
+              <IconComponent size="xs" icon={EyeOffIcon} color="slate" />
+            ) : (
+              <IconComponent size="xs" icon={EyeIcon} color="slate" />
+            )}
+          </button>
+        )}
         {error ? (
           <ExclamationFilledIcon
             className={tremorTwMerge(

--- a/src/components/input-elements/BaseInput.tsx
+++ b/src/components/input-elements/BaseInput.tsx
@@ -3,7 +3,6 @@ import React, { ReactNode, useCallback, useRef, useState } from "react";
 import { border, mergeRefs, sizing, spacing, tremorTwMerge } from "lib";
 import { ExclamationFilledIcon, EyeIcon, EyeOffIcon } from "assets";
 import { getSelectButtonColors, hasValue } from "components/input-elements/selectUtils";
-import { Icon as IconComponent } from "components/icon-elements";
 
 export interface BaseInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   type?: "text" | "password" | "email" | "url" | "number";
@@ -133,19 +132,37 @@ const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>((props, ref
           data-testid="base-input"
           {...other}
         />
-        {type === "password" && (
+        {type === "password" ? (
           <button
             className={tremorTwMerge(makeInputClassName("toggleButton"), "mr-2")}
             type="button"
             onClick={() => toggleIsPasswordVisible()}
           >
             {isPasswordVisible ? (
-              <IconComponent size="xs" icon={EyeOffIcon} color="slate" />
+              <EyeOffIcon
+                className={tremorTwMerge(
+                  // common
+                  "flex-none h-5 w-5",
+                  // light
+                  "text-tremor-content-subtle",
+                  // dark
+                  "dark:text-dark-tremor-content-subtle",
+                )}
+              />
             ) : (
-              <IconComponent size="xs" icon={EyeIcon} color="slate" />
+              <EyeIcon
+                className={tremorTwMerge(
+                  // common
+                  "flex-none h-5 w-5",
+                  // light
+                  "text-tremor-content-subtle",
+                  // dark
+                  "dark:text-dark-tremor-content-subtle",
+                )}
+              />
             )}
           </button>
-        )}
+        ) : null}
         {error ? (
           <ExclamationFilledIcon
             className={tremorTwMerge(

--- a/src/components/input-elements/BaseInput.tsx
+++ b/src/components/input-elements/BaseInput.tsx
@@ -132,7 +132,7 @@ const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>((props, ref
           data-testid="base-input"
           {...other}
         />
-        {type === "password" ? (
+        {type === "password" && !disabled ? (
           <button
             className={tremorTwMerge(makeInputClassName("toggleButton"), "mr-2")}
             type="button"
@@ -142,22 +142,22 @@ const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>((props, ref
               <EyeOffIcon
                 className={tremorTwMerge(
                   // common
-                  "flex-none h-5 w-5",
+                  "flex-none h-5 w-5 transition",
                   // light
-                  "text-tremor-content-subtle",
+                  "text-tremor-content-subtle hover:text-tremor-content",
                   // dark
-                  "dark:text-dark-tremor-content-subtle",
+                  "dark:text-dark-tremor-content-subtle hover:dark:text-dark-tremor-content",
                 )}
               />
             ) : (
               <EyeIcon
                 className={tremorTwMerge(
                   // common
-                  "flex-none h-5 w-5",
+                  "flex-none h-5 w-5 transition",
                   // light
-                  "text-tremor-content-subtle",
+                  "text-tremor-content-subtle hover:text-tremor-content",
                   // dark
-                  "dark:text-dark-tremor-content-subtle",
+                  "dark:text-dark-tremor-content-subtle hover:dark:text-dark-tremor-content",
                 )}
               />
             )}


### PR DESCRIPTION

Fixes https://github.com/tremorlabs/tremor/issues/530
## Demo
https://www.loom.com/share/a5e7e0b4415a460ea165ad239121dcfc

## What
Display the entered password value to the user

## Why
because now users can't see what they typed since the password type field hides the value

## How

Adding a button that switches input types when clicked, displaying the password when the type is `text`

## Testing
```bash
npm run storybook
````
and go to `TextInput` -> `With Type Password`

---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.
