### PR TITLE
fix: make Grid RSC compliant, again

### DIFF
--- a/src/components/layout-elements/Grid/Grid.tsx
+++ b/src/components/layout-elements/Grid/Grid.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React from "react";
 import { tremorTwMerge } from "lib";
 
 import { GridClassesMapping, gridCols, gridColsLg, gridColsMd, gridColsSm } from "./styles";
@@ -23,14 +23,12 @@ export interface GridProps extends React.HTMLAttributes<HTMLDivElement> {
 const Grid = React.forwardRef<HTMLDivElement, GridProps>((props, ref) => {
   const { numItems = 1, numItemsSm, numItemsMd, numItemsLg, children, className, ...other } = props;
 
-  const colClassNames = useMemo(() => {
-    const colsBase = getGridCols(numItems, gridCols);
-    const colsSm = getGridCols(numItemsSm, gridColsSm);
-    const colsMd = getGridCols(numItemsMd, gridColsMd);
-    const colsLg = getGridCols(numItemsLg, gridColsLg);
+  const colsBase = getGridCols(numItems, gridCols);
+  const colsSm = getGridCols(numItemsSm, gridColsSm);
+  const colsMd = getGridCols(numItemsMd, gridColsMd);
+  const colsLg = getGridCols(numItemsLg, gridColsLg);
 
-    return tremorTwMerge(colsBase, colsSm, colsMd, colsLg);
-  }, [numItems, numItemsSm, numItemsMd, numItemsLg]);
+  const colClassNames =  tremorTwMerge(colsBase, colsSm, colsMd, colsLg);
 
   return (
     <div

--- a/src/components/layout-elements/Grid/Grid.tsx
+++ b/src/components/layout-elements/Grid/Grid.tsx
@@ -28,7 +28,7 @@ const Grid = React.forwardRef<HTMLDivElement, GridProps>((props, ref) => {
   const colsMd = getGridCols(numItemsMd, gridColsMd);
   const colsLg = getGridCols(numItemsLg, gridColsLg);
 
-  const colClassNames =  tremorTwMerge(colsBase, colsSm, colsMd, colsLg);
+  const colClassNames = tremorTwMerge(colsBase, colsSm, colsMd, colsLg);
 
   return (
     <div


### PR DESCRIPTION
<!--
Please make sure to read the Contribution Guidelines:
https://github.com/tremorlabs/tremor/blob/main/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
**Description**

This fixes an undocumented breaking change where `Grid` can no longer be rendered as a server component (ie. in Next.js 13's `app` dir)

This removes `useMemo` from `Grid`, enabling it to render as a server component. 

- Acknowledging that that adding the `'use client';` directive is another option, but less ideal.

> [!NOTE]
> `Grid` used to be server-component compliant up until this diff in #499
> - https://github.com/tremorlabs/tremor/pull/499/files#diff-86176eaddcd6cebea4ac515cafc1b89420423b03f3d79e921c6e85cee9e6379eR1

**Related issue(s)**

N/A

<!--- Please link to the issue here: -->
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

**What kind of change does this PR introduce?** (check at least one)
<!-- (Update "[ ]" to "[x]" to check a box) -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**How has This been tested?**

When upgrading from `v2.8.2` to `v3.6.6`, I encountered this error. 
<img width="1030" alt="CleanShot 2023-08-26 at 12 05 06@2x" src="https://github.com/tremorlabs/tremor/assets/26389321/1a12b405-af4f-4b8d-84d8-ba60f6ac27c3">



**Screenshots (if appropriate):**


**The PR fulfills these requirements:**

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the related issue section above
- [ ] My change requires a change to the documentation. (Managed by Tremor Team)
- [ ] I have added tests to cover my changes
- [ ] Check the ["Allow edits from maintainers" option](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) while creating your PR.
- [ ] Add refs #XXX or fixes #XXX to the related issue section if your PR refers to or fixes an issue.
