### PR TITLE
fix: NumberInput does not pass event value through onChange

### DIFF
--- a/src/components/input-elements/NumberInput/NumberInput.tsx
+++ b/src/components/input-elements/NumberInput/NumberInput.tsx
@@ -81,7 +81,7 @@ const NumberInput = React.forwardRef<HTMLInputElement, NumberInputProps>((props,
               onMouseUp={() => {
                 if (disabled) return;
                 inputRef.current?.stepDown();
-                onValueChange?.(parseFloat(inputRef.current?.value ?? ""));
+                inputRef.current?.dispatchEvent(new Event("input", { bubbles: true }));
               }}
               className={tremorTwMerge(
                 !disabled && enabledArrowClasses,
@@ -104,7 +104,7 @@ const NumberInput = React.forwardRef<HTMLInputElement, NumberInputProps>((props,
               onMouseUp={() => {
                 if (disabled) return;
                 inputRef.current?.stepUp();
-                onValueChange?.(parseFloat(inputRef.current?.value ?? ""));
+                inputRef.current?.dispatchEvent(new Event("input", { bubbles: true }));
               }}
               className={tremorTwMerge(
                 !disabled && enabledArrowClasses,

--- a/src/stories/input-elements/NumberInput.stories.tsx
+++ b/src/stories/input-elements/NumberInput.stories.tsx
@@ -26,10 +26,10 @@ const Template: ComponentStory<typeof NumberInput> = (args) => {
         <NumberInput {...args} onSubmit={(value: number) => alert(value)} />
         <Text>Uncontrolled with defaultValue</Text>
         <NumberInput {...args} defaultValue={123} onSubmit={(value: number) => alert(value)} />
-        <Text>Conrolled without onChange</Text>
+        <Text>Controlled without onValueChange</Text>
         <NumberInput {...args} value={value} onSubmit={(value: number) => alert(value)} />
         <label htmlFor="a">
-          <Text>Controlled</Text>
+          <Text>Controlled with onValueChange</Text>
         </label>
         <NumberInput
           {...args}
@@ -46,6 +46,31 @@ const Template: ComponentStory<typeof NumberInput> = (args) => {
         </Button>
       </form>
       <Text>{value}</Text>
+    </Card>
+  );
+};
+
+const ControlValueWithOnChangeExample: ComponentStory<typeof NumberInput> = (args) => {
+  const [value, setValue] = useState(0);
+  return (
+    <Card>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+        }}
+        onReset={() => setValue(0)}
+      >
+        <label htmlFor="a">
+          <Text>Controlled with onChange</Text>
+        </label>
+        <NumberInput
+          {...args}
+          id={"a"}
+          value={value}
+          onChange={(e) => setValue(Number(e.target.value))}
+        />
+      </form>
+      <Text>value: {value}</Text>
     </Card>
   );
 };
@@ -104,3 +129,6 @@ WithDisabledAndError.args = {
   error: true,
   disabled: true,
 };
+
+export const ControlValueWithOnChange = ControlValueWithOnChangeExample.bind({});
+ControlValueWithOnChange.args = {};

--- a/src/stories/input-elements/NumberInput.stories.tsx
+++ b/src/stories/input-elements/NumberInput.stories.tsx
@@ -50,7 +50,7 @@ const Template: ComponentStory<typeof NumberInput> = (args) => {
   );
 };
 
-const ControlValueWithOnChangeExample: ComponentStory<typeof NumberInput> = (args) => {
+const ControlledWithOnChangeExample: ComponentStory<typeof NumberInput> = (args) => {
   const [value, setValue] = useState(0);
   return (
     <Card>
@@ -130,5 +130,5 @@ WithDisabledAndError.args = {
   disabled: true,
 };
 
-export const ControlValueWithOnChange = ControlValueWithOnChangeExample.bind({});
-ControlValueWithOnChange.args = {};
+export const ControlledWithOnChange = ControlledWithOnChangeExample.bind({});
+ControlledWithOnChange.args = {};


### PR DESCRIPTION
<!--
Please make sure to read the Contribution Guidelines:
https://github.com/tremorlabs/tremor/blob/main/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
**Description**
The bug comes from calling `inputRef.current?.stepDown()` will not trigger `onChange` event. In current version, we use `onValueChange?.(parseFloat(inputRef.current?.value ?? ""));` as a workaround. But this does not call `onChange`. 
To reutilize `onChange`, we need to create a synthetic event using `inputRef.current?.dispatchEvent(new Event("input", { bubbles: true }))` after `inputRef.current?.stepDown()`. 

Now the NumberInput could pass `event` to `onChange` handler when stepper is clicked. 

<!--- Describe your changes in detail -->

**Related issue(s)**
fix https://github.com/tremorlabs/tremor/issues/645

<!--- Please link to the issue here: -->
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

**What kind of change does this PR introduce?** (check at least one)
<!-- (Update "[ ]" to "[x]" to check a box) -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**How has This been tested?**
In storybook -> `NumberInput` -> `ControlValueWithOnChange`
<!--- Please describe how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Screenshots (if appropriate):**
N/A

**The PR fulfills these requirements:**

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It's submitted to the `main` branch
- [x] When resolving a specific issue, it's referenced in the related issue section above
- [ ] My change requires a change to the documentation. (Managed by Tremor Team)
- [x] I have added tests to cover my changes
- [x] Check the ["Allow edits from maintainers" option](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) while creating your PR.
- [x] Add refs #XXX or fixes #XXX to the related issue section if your PR refers to or fixes an issue.
