### PR TITLE
fix: Multiselect does not search with spaces

### DIFF
--- a/src/components/input-elements/MultiSelect/MultiSelect.tsx
+++ b/src/components/input-elements/MultiSelect/MultiSelect.tsx
@@ -19,6 +19,7 @@ export interface MultiSelectProps extends React.HTMLAttributes<HTMLDivElement> {
   value?: string[];
   onValueChange?: (value: string[]) => void;
   placeholder?: string;
+  placeholderSearch?: string;
   disabled?: boolean;
   icon?: React.ElementType | React.JSXElementConstructor<any>;
   children: React.ReactElement[] | React.ReactElement;
@@ -30,6 +31,7 @@ const MultiSelect = React.forwardRef<HTMLDivElement, MultiSelectProps>((props, r
     value,
     onValueChange,
     placeholder = "Select...",
+    placeholderSearch = "Search",
     disabled = false,
     icon,
     children,
@@ -212,7 +214,7 @@ const MultiSelect = React.forwardRef<HTMLDivElement, MultiSelectProps>((props, r
               <input
                 name="search"
                 type="input"
-                placeholder="Search"
+                placeholder={placeholderSearch}
                 className={tremorTwMerge(
                   // common
                   "w-full focus:outline-none focus:ring-none bg-transparent text-tremor-default",

--- a/src/components/input-elements/MultiSelect/MultiSelect.tsx
+++ b/src/components/input-elements/MultiSelect/MultiSelect.tsx
@@ -222,6 +222,11 @@ const MultiSelect = React.forwardRef<HTMLDivElement, MultiSelectProps>((props, r
                   "dark:text-dark-tremor-content-emphasis",
                   spacing.sm.paddingY,
                 )}
+                onKeyDown={(e) => {
+                  if (e.code === "Space" && (e.target as HTMLInputElement).value !== "") {
+                    e.stopPropagation();
+                  }
+                }}
                 onChange={(e) => setSearchQuery(e.target.value)}
               />
             </div>


### PR DESCRIPTION
**Description**

When the user does not have active searches he should be able to select items using SPACE and ENTER, which is exactly what is happening so far. But when the user has an active search the selection of items should work only with ENTER and SPACE should be reserved to be able to search by itself.

This is possible if we detect the SPACE key in `onKeyDown` and let only the default behaviours act by stopping the event propagation.

**Related issue(s)**
fix #650 

**What kind of change does this PR introduce?** (check at least one)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**How has This been tested?**
 In storybook -> `MultiSelect`

**Screenshots (if appropriate):**
N/A

**The PR fulfills these requirements:**

- [x] It's submitted to the `main` branch
- [x] When resolving a specific issue, it's referenced in the related issue section above
- [ ] My change requires a change to the documentation. (Managed by Tremor Team)
- [ ] I have added tests to cover my changes
- [x] Check the ["Allow edits from maintainers" option](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) while creating your PR.
- [x] Add refs #XXX or fixes #XXX to the related issue section if your PR refers to or fixes an issue.
