### PR TITLE
fix: Filled Style Today Marker in Calendar

### DIFF
--- a/src/components/input-elements/Calendar/Calendar.tsx
+++ b/src/components/input-elements/Calendar/Calendar.tsx
@@ -57,7 +57,8 @@ function Calendar<T extends DayPickerSingleProps | DayPickerRangeProps>({
         row: "flex w-full mt-0.5",
         cell: "text-center p-0 relative focus-within:relative text-tremor-default text-tremor-content-emphasis dark:text-dark-tremor-content-emphasis",
         day: "h-9 w-9 p-0 hover:bg-tremor-background-subtle dark:hover:bg-dark-tremor-background-subtle outline-tremor-brand dark:outline-dark-tremor-brand rounded-tremor-default",
-        day_today: "bg-tremor-background-subtle dark:bg-dark-tremor-background-subtle",
+        day_today:
+          "bg-tremor-brand-muted hover:bg-tremor-brand-muted dark:bg-dark-tremor-brand-muted dark:hover:bg-dark-tremor-brand-muted",
         day_selected:
           "aria-selected:bg-tremor-background-emphasis aria-selected:text-tremor-content-inverted dark:aria-selected:bg-dark-tremor-background-emphasis dark:aria-selected:text-dark-tremor-content-inverted ",
         day_disabled:


### PR DESCRIPTION
<!--
Please make sure to read the Contribution Guidelines:
https://github.com/tremorlabs/tremor/blob/main/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
**Description**

The style of "Today" marker in `Calender`  was causing visual confusion when compared to the styling of the selected range/date

<!--- Describe your changes in detail -->
On initial discussion we decided to go with Bold Text but while changing I noticed that specifically in Dark Mode i personally felt that the Bold date is not much visible and distinguishable but in Light Mode everything looked good.

So considered two versions for this fix, one with Bold Text and another with Filled Background. So you can decide which one to go for. 

This PR changes the style of Today marker with Filled Background
PR for Bold Text: #659 

**Related issue(s)**

<!--- Please link to the issue here: -->
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

#653 

**What kind of change does this PR introduce?** (check at least one)
<!-- (Update "[ ]" to "[x]" to check a box) -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**How has This been tested?**

<!--- Please describe how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
In storybook -> `InputElements` -> `DatePicker`
In storybook -> `InputElements` -> `DateRangePicker`

**Screenshots (if appropriate):**

![filled-light-date](https://github.com/tremorlabs/tremor/assets/61868840/c7743365-501c-4565-9531-79ee47420d54)
![filled-dark-date](https://github.com/tremorlabs/tremor/assets/61868840/b9e69f2d-73c2-4eb4-aa8d-f65f9f9eda70)
![filled-light-range](https://github.com/tremorlabs/tremor/assets/61868840/bb150409-9004-416c-8bc2-e846a7b9f4f0)
![filled-dark-range](https://github.com/tremorlabs/tremor/assets/61868840/b19b7693-dbdc-4e78-b2a9-16fbcf00c942)



**The PR fulfills these requirements:**

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It's submitted to the `main` branch
- [x] When resolving a specific issue, it's referenced in the related issue section above
- [ ] My change requires a change to the documentation. (Managed by Tremor Team)
- [ ] I have added tests to cover my changes
- [x] Check the ["Allow edits from maintainers" option](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) while creating your PR.
- [x] Add refs #XXX or fixes #XXX to the related issue section if your PR refers to or fixes an issue.
