### PR TITLE
Add tooltip sort by value in AreaChart

### DIFF
--- a/src/components/chart-elements/AreaChart/AreaChart.tsx
+++ b/src/components/chart-elements/AreaChart/AreaChart.tsx
@@ -27,12 +27,20 @@ import {
   tremorTwMerge,
 } from "lib";
 import { CurveType } from "../../../lib/inputTypes";
+import { CategoricalChartFunc } from "recharts/types/chart/generateCategoricalChart";
 
 export interface AreaChartProps extends BaseChartProps {
   stack?: boolean;
   tooltipOrder: "byCategory" | "byValue";
   curveType?: CurveType;
   connectNulls?: boolean;
+
+  onClickChart?: CategoricalChartFunc;
+  onMouseLeaveChart?: CategoricalChartFunc;
+  onMouseEnterChart?: CategoricalChartFunc;
+  onMouseMoveChart?: CategoricalChartFunc;
+  onMouseDownChart?: CategoricalChartFunc;
+  onMouseUpChart?: CategoricalChartFunc;
 }
 
 const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>((props, ref) => {
@@ -63,6 +71,13 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>((props, ref) 
     noDataText,
     className,
     children,
+
+    onClickChart,
+    onMouseLeaveChart,
+    onMouseEnterChart,
+    onMouseMoveChart,
+    onMouseDownChart,
+    onMouseUpChart,
     ...other
   } = props;
   const [legendHeight, setLegendHeight] = useState(60);
@@ -74,7 +89,15 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>((props, ref) 
     <div ref={ref} className={tremorTwMerge("w-full h-80", className)} {...other}>
       <ResponsiveContainer className="h-full w-full">
         {data?.length ? (
-          <ReChartsAreaChart data={data}>
+          <ReChartsAreaChart
+            data={data}
+            onClick={onClickChart}
+            onMouseLeave={onMouseLeaveChart}
+            onMouseEnter={onMouseEnterChart}
+            onMouseMove={onMouseMoveChart}
+            onMouseDown={onMouseDownChart}
+            onMouseUp={onMouseUpChart}
+          >
             {children}
             {showGridLines ? (
               <CartesianGrid

--- a/src/components/chart-elements/AreaChart/AreaChart.tsx
+++ b/src/components/chart-elements/AreaChart/AreaChart.tsx
@@ -62,6 +62,7 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>((props, ref) 
     allowDecimals = true,
     noDataText,
     className,
+    children,
     ...other
   } = props;
   const [legendHeight, setLegendHeight] = useState(60);
@@ -74,6 +75,7 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>((props, ref) 
       <ResponsiveContainer className="h-full w-full">
         {data?.length ? (
           <ReChartsAreaChart data={data}>
+            {children}
             {showGridLines ? (
               <CartesianGrid
                 className={tremorTwMerge(

--- a/src/components/chart-elements/AreaChart/AreaChart.tsx
+++ b/src/components/chart-elements/AreaChart/AreaChart.tsx
@@ -30,6 +30,7 @@ import { CurveType } from "../../../lib/inputTypes";
 
 export interface AreaChartProps extends BaseChartProps {
   stack?: boolean;
+  tooltipOrder: "byCategory" | "byValue";
   curveType?: CurveType;
   connectNulls?: boolean;
 }
@@ -40,6 +41,7 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>((props, ref) 
     categories = [],
     index,
     stack = false,
+    tooltipOrder = "byCategory",
     colors = themeColorRange,
     valueFormatter = defaultValueFormatter,
     startEndOnly = false,
@@ -134,11 +136,15 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>((props, ref) 
                 wrapperStyle={{ outline: "none" }}
                 isAnimationActive={false}
                 cursor={{ stroke: "#d1d5db", strokeWidth: 1 }} // @achi @severin
-                content={({ active, payload, label }) => (
+                itemSorter={(item) =>
+                  tooltipOrder === "byValue" && typeof item.value === "number" ? -item.value : -1
+                }
+                content={({ active, payload, label, itemSorter }) => (
                   <ChartTooltip
                     active={active}
                     payload={payload}
                     label={label}
+                    itemSorter={itemSorter}
                     valueFormatter={valueFormatter}
                     categoryColors={categoryColors}
                   />

--- a/src/components/chart-elements/common/ChartTooltip.tsx
+++ b/src/components/chart-elements/common/ChartTooltip.tsx
@@ -78,6 +78,7 @@ export interface ChartTooltipProps {
   label: string;
   categoryColors: Map<string, Color>;
   valueFormatter: ValueFormatter;
+  itemSorter?: (item: any) => number | string;
 }
 
 const ChartTooltip = ({
@@ -86,7 +87,11 @@ const ChartTooltip = ({
   label,
   categoryColors,
   valueFormatter,
+  itemSorter = () => -1,
 }: ChartTooltipProps) => {
+  payload = payload?.sort((a: any, b: any) => {
+    return itemSorter(a) < itemSorter(b) ? -1 : 1;
+  });
   if (active && payload) {
     return (
       <ChartTooltipFrame>

--- a/src/components/input-elements/Select/Select.tsx
+++ b/src/components/input-elements/Select/Select.tsx
@@ -19,6 +19,7 @@ export interface SelectProps extends React.HTMLAttributes<HTMLDivElement> {
   disabled?: boolean;
   icon?: React.JSXElementConstructor<any>;
   enableClear?: boolean;
+  listOnly?: boolean;
   children: React.ReactElement[] | React.ReactElement;
 }
 
@@ -33,6 +34,7 @@ const Select = React.forwardRef<HTMLDivElement, SelectProps>((props, ref) => {
     enableClear = false,
     children,
     className,
+    listOnly,
     ...other
   } = props;
 
@@ -67,67 +69,69 @@ const Select = React.forwardRef<HTMLDivElement, SelectProps>((props, ref) => {
     >
       {({ value }) => (
         <>
-          <Listbox.Button
-            className={tremorTwMerge(
-              // common
-              "w-full outline-none text-left whitespace-nowrap truncate rounded-tremor-default focus:ring-2 transition duration-100",
-              // light
-              "border-tremor-border shadow-tremor-input focus:border-tremor-brand-subtle focus:ring-tremor-brand-muted",
-              // dark
-              "dark:border-dark-tremor-border dark:shadow-dark-tremor-input dark:focus:border-dark-tremor-brand-subtle dark:focus:ring-dark-tremor-brand-muted",
-              Icon ? "p-10 -ml-0.5" : spacing.lg.paddingLeft,
-              spacing.fourXl.paddingRight,
-              spacing.sm.paddingY,
-              border.sm.all,
-              getSelectButtonColors(hasValue(value), disabled),
-            )}
-          >
-            {Icon && (
+          {!listOnly && (
+            <Listbox.Button
+              className={tremorTwMerge(
+                // common
+                "w-full outline-none text-left whitespace-nowrap truncate rounded-tremor-default focus:ring-2 transition duration-100",
+                // light
+                "border-tremor-border shadow-tremor-input focus:border-tremor-brand-subtle focus:ring-tremor-brand-muted",
+                // dark
+                "dark:border-dark-tremor-border dark:shadow-dark-tremor-input dark:focus:border-dark-tremor-brand-subtle dark:focus:ring-dark-tremor-brand-muted",
+                Icon ? "p-10 -ml-0.5" : spacing.lg.paddingLeft,
+                spacing.fourXl.paddingRight,
+                spacing.sm.paddingY,
+                border.sm.all,
+                getSelectButtonColors(hasValue(value), disabled),
+              )}
+            >
+              {Icon && (
+                <span
+                  className={tremorTwMerge(
+                    "absolute inset-y-0 left-0 flex items-center ml-px",
+                    spacing.md.paddingLeft,
+                  )}
+                >
+                  <Icon
+                    className={tremorTwMerge(
+                      makeSelectClassName("Icon"),
+                      // common
+                      "flex-none",
+                      // light
+                      "text-tremor-content-subtle",
+                      // dark
+                      "dark:text-dark-tremor-content-subtle",
+                      sizing.lg.height,
+                      sizing.lg.width,
+                    )}
+                  />
+                </span>
+              )}
+              <span className="w-[90%] block truncate">
+                {value ? valueToNameMapping.get(value) ?? placeholder : placeholder}
+              </span>
               <span
                 className={tremorTwMerge(
-                  "absolute inset-y-0 left-0 flex items-center ml-px",
-                  spacing.md.paddingLeft,
+                  "absolute inset-y-0 right-0 flex items-center",
+                  spacing.lg.marginRight,
                 )}
               >
-                <Icon
+                <ArrowDownHeadIcon
                   className={tremorTwMerge(
-                    makeSelectClassName("Icon"),
+                    makeSelectClassName("arrowDownIcon"),
                     // common
                     "flex-none",
                     // light
                     "text-tremor-content-subtle",
                     // dark
                     "dark:text-dark-tremor-content-subtle",
-                    sizing.lg.height,
-                    sizing.lg.width,
+                    sizing.md.height,
+                    sizing.md.width,
                   )}
                 />
               </span>
-            )}
-            <span className="w-[90%] block truncate">
-              {value ? valueToNameMapping.get(value) ?? placeholder : placeholder}
-            </span>
-            <span
-              className={tremorTwMerge(
-                "absolute inset-y-0 right-0 flex items-center",
-                spacing.lg.marginRight,
-              )}
-            >
-              <ArrowDownHeadIcon
-                className={tremorTwMerge(
-                  makeSelectClassName("arrowDownIcon"),
-                  // common
-                  "flex-none",
-                  // light
-                  "text-tremor-content-subtle",
-                  // dark
-                  "dark:text-dark-tremor-content-subtle",
-                  sizing.md.height,
-                  sizing.md.width,
-                )}
-              />
-            </span>
-          </Listbox.Button>
+            </Listbox.Button>
+          )}
           {enableClear && selectedValue ? (
             <button
               type="button"
@@ -167,6 +171,7 @@ const Select = React.forwardRef<HTMLDivElement, SelectProps>((props, ref) => {
               spacing.twoXs.marginBottom,
               border.sm.all,
             )}
+            static={listOnly}
           >
             {children}
           </Listbox.Options>

--- a/src/stories/chart-elements/AreaChart.stories.tsx
+++ b/src/stories/chart-elements/AreaChart.stories.tsx
@@ -5,6 +5,7 @@ import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { AreaChart, Card, Title } from "components";
 import { simpleBaseChartData as data, simpleBaseChartDataWithNulls } from "./helpers/testData";
 import { valueFormatter } from "./helpers/utils";
+import { ReferenceArea, ReferenceLine } from "recharts";
 
 // More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 export default {


### PR DESCRIPTION
<!--
Please make sure to read the Contribution Guidelines:
https://github.com/tremorlabs/tremor/blob/main/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
**Description**

Added a prop to `AreaChart` to allow sorting tooltip entries by value, instead of the order of labels in the `categories` prop.

Sometimes you'll want to use the same color for multiple lines in your chart--in this case, it helps reduce ambiguity when the tooltip displays fields in order of value.



**Related issue(s)**

<!--- Please link to the issue here: -->
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

**What kind of change does this PR introduce?** (check at least one)
<!-- (Update "[ ]" to "[x]" to check a box) -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:


**How has This been tested?**

I tested functionality using storybook. I can add tests if needed.

<!--- Please describe how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Screenshots (if appropriate):**

Before:
![image](https://github.com/tremorlabs/tremor/assets/19853022/379a994f-040b-4012-925b-9feb047a3fb2)

After:
![image](https://github.com/tremorlabs/tremor/assets/19853022/707fd9b1-dbbe-410f-b5bb-82b5f837b3bd)


**The PR fulfills these requirements:**

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It's submitted to the `main` branch
- [x] When resolving a specific issue, it's referenced in the related issue section above
- [x] My change requires a change to the documentation. (Managed by Tremor Team)
- [ ] I have added tests to cover my changes
- [ ] Check the ["Allow edits from maintainers" option](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) while creating your PR.
- [ ] Add refs #XXX or fixes #XXX to the related issue section if your PR refers to or fixes an issue.
