### PR TITLE
fix: Hides multiselect overflow-x scrollbar on Firefox

### DIFF
--- a/src/components/input-elements/MultiSelect/MultiSelect.tsx
+++ b/src/components/input-elements/MultiSelect/MultiSelect.tsx
@@ -122,7 +122,7 @@ const MultiSelect = React.forwardRef<HTMLDivElement, MultiSelectProps>((props, r
             )}
             <div className="h-6 flex items-center">
               {value.length > 0 ? (
-                <div className="flex flex-nowrap overflow-x-scroll [&::-webkit-scrollbar]:hidden gap-x-1 mr-5 -ml-1.5 relative">
+                <div className="flex flex-nowrap overflow-x-scroll [&::-webkit-scrollbar]:hidden [scrollbar-width:none] gap-x-1 mr-5 -ml-1.5 relative">
                   {filteredOptions
                     .filter((option) => value.includes(option.props.value))
                     .map((option, index) => {


### PR DESCRIPTION
**Description**

I've added the CSS style `scrollbar-width: none` to the MultiSelect component to prevent the horizontal scrollbar from appearing when multiple items have been selected. A comparable style already was applied for Webkit browsers.

**Related issue(s)**

Fixes issue [668](https://github.com/tremorlabs/tremor/issues/668)

**What kind of change does this PR introduce?** (check at least one)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It's submitted to the `main` branch
- [x] When resolving a specific issue, it's referenced in the related issue section above
- [ ] My change requires a change to the documentation. (Managed by Tremor Team)
- [ ] I have added tests to cover my changes
- [x] Check the ["Allow edits from maintainers" option](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) while creating your PR.
- [x] Add refs #XXX or fixes #XXX to the related issue section if your PR refers to or fixes an issue.
