### PR TITLE
fix: Improve styling in <Tabs> for variant solid

### DIFF
--- a/src/components/input-elements/Tabs/Tab.tsx
+++ b/src/components/input-elements/Tabs/Tab.tsx
@@ -52,7 +52,6 @@ const Tab = React.forwardRef<HTMLButtonElement, TabProps>((props, ref) => {
   const variant = useContext(TabVariantContext);
   const color = useContext(BaseColorContext);
   const Icon = icon;
-
   return (
     <HeadlessTab
       ref={ref}
@@ -63,7 +62,7 @@ const Tab = React.forwardRef<HTMLButtonElement, TabProps>((props, ref) => {
         // brand
         color
           ? getColorClassNames(color, colorPalette.text).selectTextColor
-          : "ui-selected:text-tremor-brand dark:ui-selected:text-dark-tremor-brand",
+          : variant === 'solid' ? "ui-selected:text-tremor-content-emphasis dark:ui-selected:text-dark-tremor-content-emphasis" : "ui-selected:text-tremor-brand dark:ui-selected:text-dark-tremor-brand",
         getVariantStyles(variant, color),
         className,
       )}

--- a/src/components/input-elements/Tabs/Tab.tsx
+++ b/src/components/input-elements/Tabs/Tab.tsx
@@ -62,7 +62,7 @@ const Tab = React.forwardRef<HTMLButtonElement, TabProps>((props, ref) => {
         // brand
         color
           ? getColorClassNames(color, colorPalette.text).selectTextColor
-          : variant === 'solid' ? "ui-selected:text-tremor-content-emphasis dark:ui-selected:text-dark-tremor-content-emphasis" : "ui-selected:text-tremor-brand dark:ui-selected:text-dark-tremor-brand",
+          : (variant === "solid" ? "ui-selected:text-tremor-content-emphasis dark:ui-selected:text-dark-tremor-content-emphasis" : "ui-selected:text-tremor-brand dark:ui-selected:text-dark-tremor-brand"),
         getVariantStyles(variant, color),
         className,
       )}

--- a/src/components/input-elements/Tabs/Tab.tsx
+++ b/src/components/input-elements/Tabs/Tab.tsx
@@ -62,7 +62,9 @@ const Tab = React.forwardRef<HTMLButtonElement, TabProps>((props, ref) => {
         // brand
         color
           ? getColorClassNames(color, colorPalette.text).selectTextColor
-          : (variant === "solid" ? "ui-selected:text-tremor-content-emphasis dark:ui-selected:text-dark-tremor-content-emphasis" : "ui-selected:text-tremor-brand dark:ui-selected:text-dark-tremor-brand"),
+          : variant === "solid"
+          ? "ui-selected:text-tremor-content-emphasis dark:ui-selected:text-dark-tremor-content-emphasis"
+          : "ui-selected:text-tremor-brand dark:ui-selected:text-dark-tremor-brand",
         getVariantStyles(variant, color),
         className,
       )}

--- a/src/components/input-elements/Tabs/TabList.tsx
+++ b/src/components/input-elements/Tabs/TabList.tsx
@@ -27,7 +27,7 @@ const variantStyles: { [key in TabVariant]: string } = {
   ),
   solid: tremorTwMerge(
     // common
-    "inline-flex p-1 rounded-tremor-default",
+    "inline-flex p-0.5 rounded-tremor-default",
     // light
     "bg-tremor-background-subtle",
     // dark


### PR DESCRIPTION
**Description**

For solid versions of Tabs, improved the styling as described in the issue #671 and changed the padding from p-1 to p-0.5

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Refactor
- [ ] Other, please describe:
- [ ] Build-related changes

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It's submitted to the `main` branch
- [x] When resolving a specific issue, it's referenced in the related issue section above
- [ ] My change requires a change to the documentation. (Managed by Tremor Team)
- [ ] I have added tests to cover my changes
- [ ] Check the ["Allow edits from maintainers" option](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) while creating your PR.
- [x] Add refs #XXX or fixes #XXX to the related issue section if your PR refers to or fixes an issue.
