### PR TITLE
fix: Disable browser autocomplete on MultiSelect input element

### DIFF
--- a/src/components/input-elements/MultiSelect/MultiSelect.tsx
+++ b/src/components/input-elements/MultiSelect/MultiSelect.tsx
@@ -262,7 +262,7 @@ const MultiSelect = React.forwardRef<HTMLDivElement, MultiSelectProps>((props, r
               <input
                 name="search"
                 type="input"
-                autocomplete="off"
+                autoComplete="off"
                 placeholder={placeholderSearch}
                 className={tremorTwMerge(
                   // common

--- a/src/components/input-elements/MultiSelect/MultiSelect.tsx
+++ b/src/components/input-elements/MultiSelect/MultiSelect.tsx
@@ -262,6 +262,7 @@ const MultiSelect = React.forwardRef<HTMLDivElement, MultiSelectProps>((props, r
               <input
                 name="search"
                 type="input"
+                autocomplete="off"
                 placeholder={placeholderSearch}
                 className={tremorTwMerge(
                   // common


### PR DESCRIPTION
<!--
Please make sure to read the Contribution Guidelines:
https://github.com/tremorlabs/tremor/blob/main/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->

<!--- Describe your changes in detail -->

This change prevents browser autocomplete being invoked when clicking on the search input element in the MultiSelect component by adding `autocomplete="off"` to the input element.

**Related issue(s)**

<!--- Please link to the issue here: -->
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

Fixes #708 

**What kind of change does this PR introduce?** (check at least one)
<!-- (Update "[ ]" to "[x]" to check a box) -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**How has This been tested?**

<!--- Please describe how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested the MultiSelect component in Firefox using Storybook. Before adding my code, the browser autocomplete appeared when double-clicking the search input within the MultiSelect. After adding my code, it did not. See the before and after screenshots below.

**Screenshots (if appropriate):**

Before:

<img width="249" alt="image" src="https://github.com/tremorlabs/tremor/assets/42025805/74c4d2b3-601e-4812-9acc-ca878502e2de">

After:

<img width="249" alt="image" src="https://github.com/tremorlabs/tremor/assets/42025805/e2d09e73-9461-4e98-90e1-7cd65c9da080">

**The PR fulfills these requirements:**

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It's submitted to the `main` branch
- [x] When resolving a specific issue, it's referenced in the related issue section above
- [ ] My change requires a change to the documentation. (Managed by Tremor Team)
- [ ] I have added tests to cover my changes
- [x] Check the ["Allow edits from maintainers" option](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) while creating your PR.
- [x] Add refs #XXX or fixes #XXX to the related issue section if your PR refers to or fixes an issue.
- [x] By contributing to Tremor, you confirm that you have read and agreed to Tremor's [CONTRIBUTING.md](https://github.com/tremorlabs/tremor/blob/main/CONTRIBUTING.md) guideline. You also agree that your contributions will be licensed under the [Apache License 2.0](https://github.com/tremorlabs/tremor/blob/main/License) license.
