### PR TITLE
fix: hover bg for secondary button in dark mode

### DIFF
--- a/src/components/input-elements/Button/styles.ts
+++ b/src/components/input-elements/Button/styles.ts
@@ -1,4 +1,4 @@
-import { Sizing, fontSize, sizing, spacing, getColorClassNames } from "lib";
+import { Sizing, fontSize, sizing, spacing, getColorClassNames, tremorTwMerge } from "lib";
 
 import { Color, ButtonVariant } from "../../../lib/inputTypes";
 import { colorPalette } from "lib/theme";
@@ -118,7 +118,10 @@ export const getButtonColors = (variant: ButtonVariant, color?: Color) => {
           : "hover:text-tremor-brand-emphasis dark:hover:text-dark-tremor-brand-emphasis",
         bgColor: getColorClassNames("transparent").bgColor,
         hoverBgColor: color
-          ? getColorClassNames(color, colorPalette.lightBackground).hoverBgColor
+          ? tremorTwMerge(
+              getColorClassNames(color, colorPalette.background).hoverBgColor,
+              "hover:bg-opacity-20 dark:hover:bg-opacity-20",
+            )
           : "hover:bg-tremor-brand-faint dark:hover:bg-dark-tremor-brand-faint",
         borderColor: color
           ? getColorClassNames(color, colorPalette.border).borderColor


### PR DESCRIPTION
<!--
Please make sure to read the Contribution Guidelines:
https://github.com/tremorlabs/tremor/blob/main/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
**Description**

<!--- Describe your changes in detail -->

**Related issue(s)**

https://github.com/tremorlabs/tremor/issues/742

<!--- Please link to the issue here: -->
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

**What kind of change does this PR introduce?** (check at least one)
<!-- (Update "[ ]" to "[x]" to check a box) -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**How has This been tested?**
I tested in storybook
<!--- Please describe how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Screenshots (if appropriate):**
Dark mode:
![image](https://github.com/tremorlabs/tremor/assets/4471043/924d3761-59c3-4b35-be5e-74587af0d225)
![image](https://github.com/tremorlabs/tremor/assets/4471043/4353dd28-358a-4de0-bfe0-d0ae888f137c)


Light mode:

![image](https://github.com/tremorlabs/tremor/assets/4471043/1597f690-00b7-4d7a-8d74-30e7e12421e0)
![image](https://github.com/tremorlabs/tremor/assets/4471043/421802bc-a30d-4a9b-b033-feff372daf8b)


**The PR fulfills these requirements:**

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It's submitted to the `main` branch
- [x] When resolving a specific issue, it's referenced in the related issue section above
- [ ] My change requires a change to the documentation. (Managed by Tremor Team)
- [ ] I have added tests to cover my changes
- [x] Check the ["Allow edits from maintainers" option](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) while creating your PR.
- [x] Add refs #XXX or fixes #XXX to the related issue section if your PR refers to or fixes an issue.
- [x] By contributing to Tremor, you confirm that you have read and agreed to Tremor's [CONTRIBUTING.md](https://github.com/tremorlabs/tremor/blob/main/CONTRIBUTING.md) guideline. You also agree that your contributions will be licensed under the [Apache License 2.0](https://github.com/tremorlabs/tremor/blob/main/License) license.
