### PR TITLE
feat: custom chart colors support

### DIFF
--- a/src/components/chart-elements/AreaChart/AreaChart.tsx
+++ b/src/components/chart-elements/AreaChart/AreaChart.tsx
@@ -20,6 +20,7 @@ import ChartTooltip from "../common/ChartTooltip";
 import NoData from "../common/NoData";
 import {
   constructCategoryColors,
+  constructCustomCategoryColors,
   getYAxisDomain,
   hasOnlyOneValueForThisKey,
 } from "../common/utils";
@@ -53,6 +54,7 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>((props, ref) 
     index,
     stack = false,
     colors = themeColorRange,
+    customChartColors = [],
     valueFormatter = defaultValueFormatter,
     startEndOnly = false,
     showXAxis = true,
@@ -85,6 +87,7 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>((props, ref) 
   const [activeDot, setActiveDot] = useState<ActiveDot | undefined>(undefined);
   const [activeLegend, setActiveLegend] = useState<string | undefined>(undefined);
   const categoryColors = constructCategoryColors(categories, colors);
+  const customCategoryColors = constructCustomCategoryColors(categories, customChartColors);
 
   const yAxisDomain = getYAxisDomain(autoMinValue, minValue, maxValue);
   const hasOnValueChange = !!onValueChange;
@@ -219,7 +222,9 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>((props, ref) 
                       <CustomTooltip
                         payload={payload?.map((payloadItem: any) => ({
                           ...payloadItem,
-                          color: categoryColors.get(payloadItem.dataKey) ?? BaseColors.Gray,
+                          color: !!customCategoryColors
+                            ? customCategoryColors.get(payloadItem.dataKey)
+                            : categoryColors.get(payloadItem.dataKey) ?? BaseColors.Gray,
                         }))}
                         active={active}
                         label={label}
@@ -231,6 +236,7 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>((props, ref) 
                         label={label}
                         valueFormatter={valueFormatter}
                         categoryColors={categoryColors}
+                        customCategoryColors={customCategoryColors}
                       />
                     )
                 ) : (
@@ -253,6 +259,7 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>((props, ref) 
                       ? (clickedLegendItem: string) => onCategoryClick(clickedLegendItem)
                       : undefined,
                     enableLegendSlider,
+                    customCategoryColors,
                   )
                 }
               />
@@ -266,9 +273,14 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>((props, ref) 
                         getColorClassNames(
                           categoryColors.get(category) ?? BaseColors.Gray,
                           colorPalette.text,
+                          !customCategoryColors ? undefined : customCategoryColors.get(category),
                         ).textColor
                       }
-                      id={categoryColors.get(category)}
+                      id={
+                        !customCategoryColors
+                          ? categoryColors.get(category)
+                          : customCategoryColors.get(category)
+                      }
                       x1="0"
                       y1="0"
                       x2="0"
@@ -289,9 +301,14 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>((props, ref) 
                         getColorClassNames(
                           categoryColors.get(category) ?? BaseColors.Gray,
                           colorPalette.text,
+                          !customCategoryColors ? undefined : customCategoryColors.get(category),
                         ).textColor
                       }
-                      id={categoryColors.get(category)}
+                      id={
+                        !customCategoryColors
+                          ? categoryColors.get(category)
+                          : customCategoryColors.get(category)
+                      }
                       x1="0"
                       y1="0"
                       x2="0"
@@ -314,6 +331,7 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>((props, ref) 
                   getColorClassNames(
                     categoryColors.get(category) ?? BaseColors.Gray,
                     colorPalette.text,
+                    !customCategoryColors ? undefined : customCategoryColors.get(category),
                   ).strokeColor
                 }
                 strokeOpacity={activeDot || (activeLegend && activeLegend !== category) ? 0.3 : 1}
@@ -328,6 +346,7 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>((props, ref) 
                         getColorClassNames(
                           categoryColors.get(dataKey) ?? BaseColors.Gray,
                           colorPalette.text,
+                          !customCategoryColors ? undefined : customCategoryColors.get(dataKey),
                         ).fillColor,
                       )}
                       cx={cx}
@@ -376,6 +395,7 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>((props, ref) 
                           getColorClassNames(
                             categoryColors.get(dataKey) ?? BaseColors.Gray,
                             colorPalette.text,
+                            !customCategoryColors ? undefined : customCategoryColors.get(dataKey),
                           ).fillColor,
                         )}
                       />
@@ -388,7 +408,11 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>((props, ref) 
                 type={curveType}
                 dataKey={category}
                 stroke=""
-                fill={`url(#${categoryColors.get(category)})`}
+                fill={`url(#${
+                  !customCategoryColors
+                    ? categoryColors.get(category)
+                    : customCategoryColors.get(category)
+                })`}
                 strokeWidth={2}
                 strokeLinejoin="round"
                 strokeLinecap="round"

--- a/src/components/chart-elements/AreaChart/AreaChart.tsx
+++ b/src/components/chart-elements/AreaChart/AreaChart.tsx
@@ -223,7 +223,7 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>((props, ref) 
                         payload={payload?.map((payloadItem: any) => ({
                           ...payloadItem,
                           color: !!customCategoryColors
-                            ? customCategoryColors.get(payloadItem.dataKey)
+                            ? customCategoryColors.get(payloadItem.dataKey) ?? BaseColors.Gray
                             : categoryColors.get(payloadItem.dataKey) ?? BaseColors.Gray,
                         }))}
                         active={active}

--- a/src/components/chart-elements/AreaChart/AreaChart.tsx
+++ b/src/components/chart-elements/AreaChart/AreaChart.tsx
@@ -222,7 +222,7 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>((props, ref) 
                       <CustomTooltip
                         payload={payload?.map((payloadItem: any) => ({
                           ...payloadItem,
-                          color: !!customCategoryColors
+                          color: customCategoryColors
                             ? customCategoryColors.get(payloadItem.dataKey) ?? BaseColors.Gray
                             : categoryColors.get(payloadItem.dataKey) ?? BaseColors.Gray,
                         }))}

--- a/src/components/chart-elements/BarChart/BarChart.tsx
+++ b/src/components/chart-elements/BarChart/BarChart.tsx
@@ -287,7 +287,7 @@ const BarChart = React.forwardRef<HTMLDivElement, BarChartProps>((props, ref) =>
                       <CustomTooltip
                         payload={payload?.map((payloadItem: any) => ({
                           ...payloadItem,
-                          color: !!customCategoryColors
+                          color: customCategoryColors
                             ? customCategoryColors.get(payloadItem.dataKey) ?? BaseColors.Gray
                             : categoryColors.get(payloadItem.dataKey) ?? BaseColors.Gray,
                         }))}

--- a/src/components/chart-elements/BarChart/BarChart.tsx
+++ b/src/components/chart-elements/BarChart/BarChart.tsx
@@ -288,7 +288,7 @@ const BarChart = React.forwardRef<HTMLDivElement, BarChartProps>((props, ref) =>
                         payload={payload?.map((payloadItem: any) => ({
                           ...payloadItem,
                           color: !!customCategoryColors
-                            ? customCategoryColors.get(payloadItem.dataKey)
+                            ? customCategoryColors.get(payloadItem.dataKey) ?? BaseColors.Gray
                             : categoryColors.get(payloadItem.dataKey) ?? BaseColors.Gray,
                         }))}
                         active={active}

--- a/src/components/chart-elements/BarChart/BarChart.tsx
+++ b/src/components/chart-elements/BarChart/BarChart.tsx
@@ -17,7 +17,12 @@ import BaseChartProps from "../common/BaseChartProps";
 import ChartLegend from "../common/ChartLegend";
 import ChartTooltip from "../common/ChartTooltip";
 import NoData from "../common/NoData";
-import { constructCategoryColors, deepEqual, getYAxisDomain } from "../common/utils";
+import {
+  constructCategoryColors,
+  constructCustomCategoryColors,
+  deepEqual,
+  getYAxisDomain,
+} from "../common/utils";
 
 import { BaseColors, defaultValueFormatter, themeColorRange } from "lib";
 import { AxisDomain } from "recharts/types/util/types";
@@ -68,6 +73,7 @@ const BarChart = React.forwardRef<HTMLDivElement, BarChartProps>((props, ref) =>
     categories = [],
     index,
     colors = themeColorRange,
+    customChartColors = [],
     valueFormatter = defaultValueFormatter,
     layout = "horizontal",
     stack = false,
@@ -98,6 +104,7 @@ const BarChart = React.forwardRef<HTMLDivElement, BarChartProps>((props, ref) =>
   const paddingValue = !showXAxis && !showYAxis ? 0 : 20;
   const [legendHeight, setLegendHeight] = useState(60);
   const categoryColors = constructCategoryColors(categories, colors);
+  const customCategoryColors = constructCustomCategoryColors(categories, customChartColors);
   const [activeBar, setActiveBar] = React.useState<any | undefined>(undefined);
   const [activeLegend, setActiveLegend] = useState<string | undefined>(undefined);
   const hasOnValueChange = !!onValueChange;
@@ -280,7 +287,9 @@ const BarChart = React.forwardRef<HTMLDivElement, BarChartProps>((props, ref) =>
                       <CustomTooltip
                         payload={payload?.map((payloadItem: any) => ({
                           ...payloadItem,
-                          color: categoryColors.get(payloadItem.dataKey) ?? BaseColors.Gray,
+                          color: !!customCategoryColors
+                            ? customCategoryColors.get(payloadItem.dataKey)
+                            : categoryColors.get(payloadItem.dataKey) ?? BaseColors.Gray,
                         }))}
                         active={active}
                         label={label}
@@ -292,6 +301,7 @@ const BarChart = React.forwardRef<HTMLDivElement, BarChartProps>((props, ref) =>
                         label={label}
                         valueFormatter={valueFormatter}
                         categoryColors={categoryColors}
+                        customCategoryColors={customCategoryColors}
                       />
                     )
                 ) : (
@@ -314,6 +324,7 @@ const BarChart = React.forwardRef<HTMLDivElement, BarChartProps>((props, ref) =>
                       ? (clickedLegendItem: string) => onCategoryClick(clickedLegendItem)
                       : undefined,
                     enableLegendSlider,
+                    customCategoryColors,
                   )
                 }
               />
@@ -324,6 +335,7 @@ const BarChart = React.forwardRef<HTMLDivElement, BarChartProps>((props, ref) =>
                   getColorClassNames(
                     categoryColors.get(category) ?? BaseColors.Gray,
                     colorPalette.background,
+                    !customCategoryColors ? undefined : customCategoryColors.get(category),
                   ).fillColor,
                   onValueChange ? "cursor-pointer" : "",
                 )}

--- a/src/components/chart-elements/DonutChart/DonutChart.tsx
+++ b/src/components/chart-elements/DonutChart/DonutChart.tsx
@@ -26,6 +26,7 @@ export interface DonutChartProps extends BaseAnimationTimingProps {
   category?: string;
   index?: string;
   colors?: Color[];
+  customChartColors?: string[];
   variant?: DonutChartVariant;
   valueFormatter?: ValueFormatter;
   label?: string;
@@ -79,6 +80,7 @@ const DonutChart = React.forwardRef<HTMLDivElement, DonutChartProps>((props, ref
     category = "value",
     index = "name",
     colors = themeColorRange,
+    customChartColors = [],
     variant = "donut",
     valueFormatter = defaultValueFormatter,
     label,
@@ -160,7 +162,7 @@ const DonutChart = React.forwardRef<HTMLDivElement, DonutChartProps>((props, ref
                 "stroke-tremor-background dark:stroke-dark-tremor-background",
                 onValueChange ? "cursor-pointer" : "cursor-default",
               )}
-              data={parseData(data, colors)}
+              data={parseData(data, colors, customChartColors)}
               cx="50%"
               cy="50%"
               startAngle={90}

--- a/src/components/chart-elements/DonutChart/DonutChartTooltip.tsx
+++ b/src/components/chart-elements/DonutChart/DonutChartTooltip.tsx
@@ -21,6 +21,7 @@ export const DonutChartTooltip = ({ active, payload, valueFormatter }: DonutChar
             value={valueFormatter(payloadRow.value)}
             name={payloadRow.name}
             color={payloadRow.payload.color}
+            customColor={payloadRow.payload.customColor}
           />
         </div>
       </ChartTooltipFrame>

--- a/src/components/chart-elements/DonutChart/inputParser.ts
+++ b/src/components/chart-elements/DonutChart/inputParser.ts
@@ -1,15 +1,21 @@
 import { BaseColors, colorPalette, getColorClassNames, sumNumericArray } from "lib";
 import { Color, ValueFormatter } from "../../../lib/inputTypes";
 
-export const parseData = (data: any[], colors: Color[]) =>
+export const parseData = (data: any[], colors: Color[], customColors?: string[]) =>
   data.map((dataPoint: any, idx: number) => {
     const baseColor = idx < colors.length ? colors[idx] : BaseColors.Gray;
+    const baseColorCustom =
+      customColors && idx < customColors.length ? customColors[idx] : BaseColors.Gray;
     return {
       ...dataPoint,
       // explicitly adding color key if not present for tooltip coloring
       color: baseColor,
-      className: getColorClassNames(baseColor ?? BaseColors.Gray, colorPalette.background)
-        .fillColor,
+      customColor: baseColorCustom,
+      className: getColorClassNames(
+        baseColor ?? BaseColors.Gray,
+        colorPalette.background,
+        !customColors ? undefined : customColors[idx],
+      ).fillColor,
       fill: "",
     };
   });

--- a/src/components/chart-elements/LineChart/LineChart.tsx
+++ b/src/components/chart-elements/LineChart/LineChart.tsx
@@ -219,7 +219,7 @@ const LineChart = React.forwardRef<HTMLDivElement, LineChartProps>((props, ref) 
                         payload={payload?.map((payloadItem: any) => ({
                           ...payloadItem,
                           color: !!customCategoryColors
-                            ? customCategoryColors.get(payloadItem.dataKey)
+                            ? customCategoryColors.get(payloadItem.dataKey) ?? BaseColors.Gray
                             : categoryColors.get(payloadItem.dataKey) ?? BaseColors.Gray,
                         }))}
                         active={active}

--- a/src/components/chart-elements/LineChart/LineChart.tsx
+++ b/src/components/chart-elements/LineChart/LineChart.tsx
@@ -218,7 +218,7 @@ const LineChart = React.forwardRef<HTMLDivElement, LineChartProps>((props, ref) 
                       <CustomTooltip
                         payload={payload?.map((payloadItem: any) => ({
                           ...payloadItem,
-                          color: !!customCategoryColors
+                          color: customCategoryColors
                             ? customCategoryColors.get(payloadItem.dataKey) ?? BaseColors.Gray
                             : categoryColors.get(payloadItem.dataKey) ?? BaseColors.Gray,
                         }))}

--- a/src/components/chart-elements/LineChart/LineChart.tsx
+++ b/src/components/chart-elements/LineChart/LineChart.tsx
@@ -19,6 +19,7 @@ import ChartTooltip from "../common/ChartTooltip";
 import NoData from "../common/NoData";
 import {
   constructCategoryColors,
+  constructCustomCategoryColors,
   getYAxisDomain,
   hasOnlyOneValueForThisKey,
 } from "../common/utils";
@@ -49,6 +50,7 @@ const LineChart = React.forwardRef<HTMLDivElement, LineChartProps>((props, ref) 
     categories = [],
     index,
     colors = themeColorRange,
+    customChartColors = [],
     valueFormatter = defaultValueFormatter,
     startEndOnly = false,
     showXAxis = true,
@@ -80,6 +82,7 @@ const LineChart = React.forwardRef<HTMLDivElement, LineChartProps>((props, ref) 
   const [activeDot, setActiveDot] = useState<ActiveDot | undefined>(undefined);
   const [activeLegend, setActiveLegend] = useState<string | undefined>(undefined);
   const categoryColors = constructCategoryColors(categories, colors);
+  const customCategoryColors = constructCustomCategoryColors(categories, customChartColors);
 
   const yAxisDomain = getYAxisDomain(autoMinValue, minValue, maxValue);
   const hasOnValueChange = !!onValueChange;
@@ -215,7 +218,9 @@ const LineChart = React.forwardRef<HTMLDivElement, LineChartProps>((props, ref) 
                       <CustomTooltip
                         payload={payload?.map((payloadItem: any) => ({
                           ...payloadItem,
-                          color: categoryColors.get(payloadItem.dataKey) ?? BaseColors.Gray,
+                          color: !!customCategoryColors
+                            ? customCategoryColors.get(payloadItem.dataKey)
+                            : categoryColors.get(payloadItem.dataKey) ?? BaseColors.Gray,
                         }))}
                         active={active}
                         label={label}
@@ -227,6 +232,7 @@ const LineChart = React.forwardRef<HTMLDivElement, LineChartProps>((props, ref) 
                         label={label}
                         valueFormatter={valueFormatter}
                         categoryColors={categoryColors}
+                        customCategoryColors={customCategoryColors}
                       />
                     )
                 ) : (
@@ -250,6 +256,7 @@ const LineChart = React.forwardRef<HTMLDivElement, LineChartProps>((props, ref) 
                       ? (clickedLegendItem: string) => onCategoryClick(clickedLegendItem)
                       : undefined,
                     enableLegendSlider,
+                    customCategoryColors,
                   )
                 }
               />
@@ -260,6 +267,7 @@ const LineChart = React.forwardRef<HTMLDivElement, LineChartProps>((props, ref) 
                   getColorClassNames(
                     categoryColors.get(category) ?? BaseColors.Gray,
                     colorPalette.text,
+                    !customCategoryColors ? undefined : customCategoryColors.get(category),
                   ).strokeColor,
                 )}
                 strokeOpacity={activeDot || (activeLegend && activeLegend !== category) ? 0.3 : 1}
@@ -274,6 +282,7 @@ const LineChart = React.forwardRef<HTMLDivElement, LineChartProps>((props, ref) 
                         getColorClassNames(
                           categoryColors.get(dataKey) ?? BaseColors.Gray,
                           colorPalette.text,
+                          !customCategoryColors ? undefined : customCategoryColors.get(category),
                         ).fillColor,
                       )}
                       cx={cx}
@@ -322,6 +331,7 @@ const LineChart = React.forwardRef<HTMLDivElement, LineChartProps>((props, ref) 
                           getColorClassNames(
                             categoryColors.get(dataKey) ?? BaseColors.Gray,
                             colorPalette.text,
+                            !customCategoryColors ? undefined : customCategoryColors.get(dataKey),
                           ).fillColor,
                         )}
                       />

--- a/src/components/chart-elements/ScatterChart/ScatterChart.tsx
+++ b/src/components/chart-elements/ScatterChart/ScatterChart.tsx
@@ -288,7 +288,7 @@ const ScatterChart = React.forwardRef<HTMLDivElement, ScatterChartProps>((props,
                       <CustomTooltip
                         payload={payload?.map((payloadItem) => ({
                           ...payloadItem,
-                          color: !!customCategoryColors
+                          color: customCategoryColors
                             ? customCategoryColors.get(color) ?? BaseColors.Gray
                             : categoryColors.get(color) ?? BaseColors.Gray,
                         }))}

--- a/src/components/chart-elements/ScatterChart/ScatterChartTooltip.tsx
+++ b/src/components/chart-elements/ScatterChart/ScatterChartTooltip.tsx
@@ -60,6 +60,7 @@ export const ChartTooltipRow = ({ value, name }: ChartTooltipRowProps) => (
 export interface ScatterChartTooltipProps {
   label: string;
   categoryColors: Map<string, Color>;
+  customCategoryColors?: Map<string, string>;
   active: boolean | undefined;
   payload: any;
   valueFormatter: ScatterChartValueFormatter;
@@ -75,6 +76,7 @@ const ScatterChartTooltip = ({
   axis,
   category,
   categoryColors,
+  customCategoryColors,
 }: ScatterChartTooltipProps) => {
   if (active && payload) {
     return (
@@ -105,6 +107,9 @@ const ScatterChartTooltip = ({
                   ? categoryColors.get(payload?.[0]?.payload[category]) ?? BaseColors.Blue
                   : BaseColors.Blue,
                 colorPalette.background,
+                !customCategoryColors || !category
+                  ? undefined
+                  : customCategoryColors.get(payload?.[0]?.payload[category]),
               ).bgColor,
               sizing.sm.height,
               sizing.sm.width,

--- a/src/components/chart-elements/common/BaseChartProps.tsx
+++ b/src/components/chart-elements/common/BaseChartProps.tsx
@@ -18,6 +18,7 @@ interface BaseChartProps extends BaseAnimationTimingProps, React.HTMLAttributes<
   categories: string[];
   index: string;
   colors?: Color[];
+  customChartColors?: string[];
   valueFormatter?: ValueFormatter;
   startEndOnly?: boolean;
   showXAxis?: boolean;

--- a/src/components/chart-elements/common/ChartLegend.tsx
+++ b/src/components/chart-elements/common/ChartLegend.tsx
@@ -10,8 +10,9 @@ const ChartLegend = (
   categoryColors: Map<string, Color>,
   setLegendHeight: React.Dispatch<React.SetStateAction<number>>,
   activeLegend: string | undefined,
-  onClick?: (category: string, color: Color) => void,
+  onClick?: (category: string, color: Color, customColor?: string) => void,
   enableLegendSlider?: boolean,
+  customCategoryColors?: Map<string, string>,
 ) => {
   const legendRef = useRef<HTMLDivElement>(null);
 
@@ -30,6 +31,11 @@ const ChartLegend = (
       <Legend
         categories={filteredPayload.map((entry: any) => entry.value)}
         colors={filteredPayload.map((entry: any) => categoryColors.get(entry.value))}
+        customColors={
+          !customCategoryColors
+            ? undefined
+            : filteredPayload.map((entry: any) => customCategoryColors.get(entry.value))
+        }
         onClickLegendItem={onClick}
         activeLegend={activeLegend}
         enableLegendSlider={enableLegendSlider}

--- a/src/components/chart-elements/common/ChartTooltip.tsx
+++ b/src/components/chart-elements/common/ChartTooltip.tsx
@@ -25,9 +25,10 @@ export interface ChartTooltipRowProps {
   value: string;
   name: string;
   color: Color;
+  customColor?: string;
 }
 
-export const ChartTooltipRow = ({ value, name, color }: ChartTooltipRowProps) => (
+export const ChartTooltipRow = ({ value, name, color, customColor }: ChartTooltipRowProps) => (
   <div className="flex items-center justify-between space-x-8">
     <div className="flex items-center space-x-2">
       <span
@@ -38,7 +39,7 @@ export const ChartTooltipRow = ({ value, name, color }: ChartTooltipRowProps) =>
           "border-tremor-background shadow-tremor-card",
           // dark
           "dark:border-dark-tremor-background dark:shadow-dark-tremor-card",
-          getColorClassNames(color, colorPalette.background).bgColor,
+          getColorClassNames(color, colorPalette.background, customColor).bgColor,
           sizing.sm.height,
           sizing.sm.width,
           border.md.all,
@@ -77,6 +78,7 @@ export interface ChartTooltipProps {
   payload: any;
   label: string;
   categoryColors: Map<string, Color>;
+  customCategoryColors?: Map<string, string>;
   valueFormatter: ValueFormatter;
 }
 
@@ -85,6 +87,7 @@ const ChartTooltip = ({
   payload,
   label,
   categoryColors,
+  customCategoryColors,
   valueFormatter,
 }: ChartTooltipProps) => {
   if (active && payload) {
@@ -124,6 +127,7 @@ const ChartTooltip = ({
               value={valueFormatter(value)}
               name={name}
               color={categoryColors.get(name) ?? BaseColors.Blue}
+              customColor={!customCategoryColors ? undefined : customCategoryColors.get(name)}
             />
           ))}
         </div>

--- a/src/components/chart-elements/common/utils.ts
+++ b/src/components/chart-elements/common/utils.ts
@@ -11,6 +11,20 @@ export const constructCategoryColors = (
   return categoryColors;
 };
 
+export const constructCustomCategoryColors = (
+  categories: string[],
+  colors: string[],
+): Map<string, string> | undefined => {
+  if (!colors.length) {
+    return;
+  }
+  const categoryColors = new Map<string, string>();
+  categories.forEach((category, idx) => {
+    categoryColors.set(category, colors[idx]);
+  });
+  return categoryColors;
+};
+
 export const getYAxisDomain = (
   autoMinValue: boolean,
   minValue: number | undefined,

--- a/src/components/spark-elements/SparkAreaChart/SparkAreaChart.tsx
+++ b/src/components/spark-elements/SparkAreaChart/SparkAreaChart.tsx
@@ -5,7 +5,10 @@ import { Area, AreaChart as ReChartsAreaChart, ResponsiveContainer, XAxis } from
 import { BaseColors, colorPalette, getColorClassNames, themeColorRange, tremorTwMerge } from "lib";
 import { CurveType } from "../../../lib/inputTypes";
 import BaseSparkChartProps from "../common/BaseSparkChartProps";
-import { constructCategoryColors } from "components/chart-elements/common/utils";
+import {
+  constructCategoryColors,
+  constructCustomCategoryColors,
+} from "components/chart-elements/common/utils";
 import NoData from "components/chart-elements/common/NoData";
 
 export interface SparkAreaChartProps extends BaseSparkChartProps {
@@ -22,6 +25,7 @@ const AreaChart = React.forwardRef<HTMLDivElement, SparkAreaChartProps>((props, 
     index,
     stack = false,
     colors = themeColorRange,
+    customChartColors = [],
     showAnimation = false,
     animationDuration = 900,
     showGradient = true,
@@ -32,6 +36,7 @@ const AreaChart = React.forwardRef<HTMLDivElement, SparkAreaChartProps>((props, 
     ...other
   } = props;
   const categoryColors = constructCategoryColors(categories, colors);
+  const customCategoryColors = constructCustomCategoryColors(categories, customChartColors);
 
   return (
     <div ref={ref} className={tremorTwMerge("w-28 h-12", className)} {...other}>
@@ -48,9 +53,14 @@ const AreaChart = React.forwardRef<HTMLDivElement, SparkAreaChartProps>((props, 
                         getColorClassNames(
                           categoryColors.get(category) ?? BaseColors.Gray,
                           colorPalette.text,
+                          !customCategoryColors ? undefined : customCategoryColors.get(category),
                         ).textColor
                       }
-                      id={categoryColors.get(category)}
+                      id={
+                        !customCategoryColors
+                          ? categoryColors.get(category)
+                          : customCategoryColors.get(category)
+                      }
                       x1="0"
                       y1="0"
                       x2="0"
@@ -65,9 +75,14 @@ const AreaChart = React.forwardRef<HTMLDivElement, SparkAreaChartProps>((props, 
                         getColorClassNames(
                           categoryColors.get(category) ?? BaseColors.Gray,
                           colorPalette.text,
+                          !customCategoryColors ? undefined : customCategoryColors.get(category),
                         ).textColor
                       }
-                      id={categoryColors.get(category)}
+                      id={
+                        !customCategoryColors
+                          ? categoryColors.get(category)
+                          : customCategoryColors.get(category)
+                      }
                       x1="0"
                       y1="0"
                       x2="0"
@@ -85,6 +100,7 @@ const AreaChart = React.forwardRef<HTMLDivElement, SparkAreaChartProps>((props, 
                   getColorClassNames(
                     categoryColors.get(category) ?? BaseColors.Gray,
                     colorPalette.text,
+                    !customCategoryColors ? undefined : customCategoryColors.get(category),
                   ).strokeColor
                 }
                 strokeOpacity={1}
@@ -94,7 +110,11 @@ const AreaChart = React.forwardRef<HTMLDivElement, SparkAreaChartProps>((props, 
                 type={curveType}
                 dataKey={category}
                 stroke=""
-                fill={`url(#${categoryColors.get(category)})`}
+                fill={`url(#${
+                  !customCategoryColors
+                    ? categoryColors.get(category)
+                    : customCategoryColors.get(category)
+                })`}
                 strokeWidth={2}
                 strokeLinejoin="round"
                 strokeLinecap="round"

--- a/src/components/spark-elements/SparkBarChart/SparkBarChart.tsx
+++ b/src/components/spark-elements/SparkBarChart/SparkBarChart.tsx
@@ -6,7 +6,10 @@ import { Bar, BarChart as ReChartsBarChart, ResponsiveContainer, XAxis } from "r
 
 import { BaseColors, themeColorRange } from "lib";
 import BaseSparkChartProps from "../common/BaseSparkChartProps";
-import { constructCategoryColors } from "components/chart-elements/common/utils";
+import {
+  constructCategoryColors,
+  constructCustomCategoryColors,
+} from "components/chart-elements/common/utils";
 import NoData from "components/chart-elements/common/NoData";
 
 export interface SparkBarChartProps extends BaseSparkChartProps {
@@ -20,6 +23,7 @@ const SparkBarChart = React.forwardRef<HTMLDivElement, SparkBarChartProps>((prop
     categories = [],
     index,
     colors = themeColorRange,
+    customChartColors = [],
     stack = false,
     relative = false,
     animationDuration = 900,
@@ -29,6 +33,7 @@ const SparkBarChart = React.forwardRef<HTMLDivElement, SparkBarChartProps>((prop
     ...other
   } = props;
   const categoryColors = constructCategoryColors(categories, colors);
+  const customCategoryColors = constructCustomCategoryColors(categories, customChartColors);
 
   return (
     <div ref={ref} className={tremorTwMerge("w-28 h-12", className)} {...other}>
@@ -46,6 +51,7 @@ const SparkBarChart = React.forwardRef<HTMLDivElement, SparkBarChartProps>((prop
                   getColorClassNames(
                     categoryColors.get(category) ?? BaseColors.Gray,
                     colorPalette.background,
+                    !customCategoryColors ? undefined : customCategoryColors.get(category),
                   ).fillColor,
                 )}
                 key={category}

--- a/src/components/spark-elements/SparkLineChart/SparkLineChart.tsx
+++ b/src/components/spark-elements/SparkLineChart/SparkLineChart.tsx
@@ -5,7 +5,10 @@ import { Line, LineChart as ReChartsLineChart, ResponsiveContainer, XAxis } from
 import { BaseColors, colorPalette, getColorClassNames, themeColorRange, tremorTwMerge } from "lib";
 import { CurveType } from "../../../lib/inputTypes";
 import BaseSparkChartProps from "../common/BaseSparkChartProps";
-import { constructCategoryColors } from "components/chart-elements/common/utils";
+import {
+  constructCategoryColors,
+  constructCustomCategoryColors,
+} from "components/chart-elements/common/utils";
 import NoData from "components/chart-elements/common/NoData";
 
 export interface SparkLineChartProps extends BaseSparkChartProps {
@@ -19,6 +22,7 @@ const SparkLineChart = React.forwardRef<HTMLDivElement, SparkLineChartProps>((pr
     categories = [],
     index,
     colors = themeColorRange,
+    customChartColors = [],
     animationDuration = 900,
     showAnimation = false,
     curveType = "linear",
@@ -28,6 +32,7 @@ const SparkLineChart = React.forwardRef<HTMLDivElement, SparkLineChartProps>((pr
     ...other
   } = props;
   const categoryColors = constructCategoryColors(categories, colors);
+  const customCategoryColors = constructCustomCategoryColors(categories, customChartColors);
 
   return (
     <div ref={ref} className={tremorTwMerge("w-28 h-12", className)} {...other}>
@@ -41,6 +46,7 @@ const SparkLineChart = React.forwardRef<HTMLDivElement, SparkLineChartProps>((pr
                   getColorClassNames(
                     categoryColors.get(category) ?? BaseColors.Gray,
                     colorPalette.text,
+                    !customCategoryColors ? undefined : customCategoryColors.get(category),
                   ).strokeColor,
                 )}
                 strokeOpacity={1}

--- a/src/components/spark-elements/common/BaseSparkChartProps.tsx
+++ b/src/components/spark-elements/common/BaseSparkChartProps.tsx
@@ -19,6 +19,7 @@ interface BaseSparkChartProps
   categories: string[];
   index: string;
   colors?: Color[];
+  customChartColors?: string[];
   noDataText?: string;
 }
 

--- a/src/components/text-elements/Legend/Legend.tsx
+++ b/src/components/text-elements/Legend/Legend.tsx
@@ -17,11 +17,12 @@ const makeLegendClassName = makeClassName("Legend");
 export interface LegendItemProps {
   name: string;
   color: Color;
-  onClick?: (name: string, color: Color) => void;
+  customColor?: string;
+  onClick?: (name: string, color: Color, customColor?: string) => void;
   activeLegend?: string;
 }
 
-const LegendItem = ({ name, color, onClick, activeLegend }: LegendItemProps) => {
+const LegendItem = ({ name, color, customColor, onClick, activeLegend }: LegendItemProps) => {
   const hasOnValueChange = !!onClick;
   return (
     <li
@@ -39,13 +40,13 @@ const LegendItem = ({ name, color, onClick, activeLegend }: LegendItemProps) => 
       )}
       onClick={(e) => {
         e.stopPropagation();
-        onClick?.(name, color);
+        onClick?.(name, color, customColor);
       }}
     >
       <svg
         className={tremorTwMerge(
           "flex-none",
-          getColorClassNames(color, colorPalette.text).textColor,
+          getColorClassNames(color, colorPalette.text, customColor).textColor,
           sizing.xs.height,
           sizing.xs.width,
           spacing.xs.marginRight,
@@ -143,6 +144,7 @@ const ScrollButton = ({ icon, onClick, disabled }: ScrollButtonProps) => {
 export interface LegendProps extends React.OlHTMLAttributes<HTMLOListElement> {
   categories: string[];
   colors?: Color[];
+  customColors?: string[];
   onClickLegendItem?: (category: string, color: Color) => void;
   activeLegend?: string;
   enableLegendSlider?: boolean;
@@ -158,6 +160,7 @@ const Legend = React.forwardRef<HTMLOListElement, LegendProps>((props, ref) => {
     categories,
     colors = themeColorRange,
     className,
+    customColors = [],
     onClickLegendItem,
     activeLegend,
     enableLegendSlider = false,
@@ -268,6 +271,7 @@ const Legend = React.forwardRef<HTMLOListElement, LegendProps>((props, ref) => {
             key={`item-${idx}`}
             name={category}
             color={colors[idx]}
+            customColor={!customColors.length ? undefined : customColors[idx]}
             onClick={onClickLegendItem}
             activeLegend={activeLegend}
           />

--- a/src/lib/utils.tsx
+++ b/src/lib/utils.tsx
@@ -73,21 +73,33 @@ interface ColorClassNames {
 export function getColorClassNames(
   color: Color | "white" | "black" | "transparent",
   shade?: number,
+  customColor?: string,
 ): ColorClassNames {
-  if (color === "white" || color === "black" || color === "transparent" || !shade) {
+  if (
+    color === "white" ||
+    color === "black" ||
+    color === "transparent" ||
+    !!customColor ||
+    !shade
+  ) {
+    const unshadedColor = !customColor
+      ? color
+      : customColor.includes("#")
+      ? `[${customColor}]`
+      : customColor;
     return {
-      bgColor: `bg-${color}`,
-      hoverBgColor: `hover:bg-${color}`,
-      selectBgColor: `ui-selected:bg-${color}`,
-      textColor: `text-${color}`,
-      selectTextColor: `ui-selected:text-${color}`,
-      hoverTextColor: `hover:text-${color}`,
-      borderColor: `border-${color}`,
-      selectBorderColor: `ui-selected:border-${color}`,
-      hoverBorderColor: `hover:border-${color}`,
-      ringColor: `ring-${color}`,
-      strokeColor: `stroke-${color}`,
-      fillColor: `fill-${color}`,
+      bgColor: `bg-${unshadedColor}`,
+      hoverBgColor: `hover:bg-${unshadedColor}`,
+      selectBgColor: `ui-selected:bg-${unshadedColor}`,
+      textColor: `text-${unshadedColor}`,
+      selectTextColor: `ui-selected:text-${unshadedColor}`,
+      hoverTextColor: `hover:text-${unshadedColor}`,
+      borderColor: `border-${unshadedColor}`,
+      selectBorderColor: `ui-selected:border-${unshadedColor}`,
+      hoverBorderColor: `hover:border-${unshadedColor}`,
+      ringColor: `ring-${unshadedColor}`,
+      strokeColor: `stroke-${unshadedColor}`,
+      fillColor: `fill-${unshadedColor}`,
     };
   }
   return {

--- a/src/stories/chart-elements/AreaChart.stories.tsx
+++ b/src/stories/chart-elements/AreaChart.stories.tsx
@@ -62,12 +62,7 @@ export const OtherColors: Story = {
 
 export const CustomColors: Story = {
   args: {
-    categories: ["Leads", "Sales", "Successful Payments"],
-    data: data.map((item, index) => ({
-      ...item,
-      Leads: 2000 + index * 100,
-    })),
-    customChartColors: ["#32a852", "#fcba03", "orange-600"],
+    customChartColors: ["#32a852", "orange-600"],
   },
 };
 

--- a/src/stories/chart-elements/AreaChart.stories.tsx
+++ b/src/stories/chart-elements/AreaChart.stories.tsx
@@ -60,6 +60,17 @@ export const OtherColors: Story = {
   args: { colors: ["rose", "purple"] },
 };
 
+export const CustomColors: Story = {
+  args: {
+    categories: ["Leads", "Sales", "Successful Payments"],
+    data: data.map((item, index) => ({
+      ...item,
+      Leads: 2000 + index * 100,
+    })),
+    customChartColors: ["#32a852", "#fcba03", "orange-600"],
+  },
+};
+
 export const NoGradient: Story = {
   args: { showGradient: false },
 };

--- a/src/stories/chart-elements/BarChart.stories.tsx
+++ b/src/stories/chart-elements/BarChart.stories.tsx
@@ -90,6 +90,17 @@ export const OtherColors: Story = {
   args: { colors: ["blue", "green"] },
 };
 
+export const CustomColors: Story = {
+  args: {
+    categories: ["Leads", "Sales", "Successful Payments"],
+    data: data.map((item, index) => ({
+      ...item,
+      Leads: 2000 + index * 100,
+    })),
+    customChartColors: ["#32a852", "#fcba03", "orange-600"],
+  },
+};
+
 export const ChangedCategoriesOrder: Story = {
   args: { categories: ["Successful Payments", "Sales"] },
 };

--- a/src/stories/chart-elements/BarChart.stories.tsx
+++ b/src/stories/chart-elements/BarChart.stories.tsx
@@ -92,12 +92,7 @@ export const OtherColors: Story = {
 
 export const CustomColors: Story = {
   args: {
-    categories: ["Leads", "Sales", "Successful Payments"],
-    data: data.map((item, index) => ({
-      ...item,
-      Leads: 2000 + index * 100,
-    })),
-    customChartColors: ["#32a852", "#fcba03", "orange-600"],
+    customChartColors: ["#32a852", "orange-600"],
   },
 };
 

--- a/src/stories/chart-elements/DonutChart.stories.tsx
+++ b/src/stories/chart-elements/DonutChart.stories.tsx
@@ -77,6 +77,12 @@ export const OtherColors: Story = {
   args: { colors: ["blue", "amber", "sky", "emerald", "rose", "orange"] },
 };
 
+export const CustomColors: Story = {
+  args: {
+    customChartColors: ["#32a852", "#fcba03", "orange-600", "blue-400", "violet-400", "rose-400"],
+  },
+};
+
 export const MoreDatapointsThanColors: Story = {
   args: {
     data: [

--- a/src/stories/chart-elements/LineChart.stories.tsx
+++ b/src/stories/chart-elements/LineChart.stories.tsx
@@ -54,6 +54,17 @@ export const OtherColors: Story = {
   args: { colors: ["rose", "purple"] },
 };
 
+export const CustomColors: Story = {
+  args: {
+    categories: ["Leads", "Sales", "Successful Payments"],
+    data: data.map((item, index) => ({
+      ...item,
+      Leads: 2000 + index * 100,
+    })),
+    customChartColors: ["#32a852", "#fcba03", "orange-600"],
+  },
+};
+
 export const ChangedCategoriesOrder: Story = {
   args: { categories: ["Successful Payments", "Sales"] },
 };

--- a/src/stories/chart-elements/LineChart.stories.tsx
+++ b/src/stories/chart-elements/LineChart.stories.tsx
@@ -56,12 +56,7 @@ export const OtherColors: Story = {
 
 export const CustomColors: Story = {
   args: {
-    categories: ["Leads", "Sales", "Successful Payments"],
-    data: data.map((item, index) => ({
-      ...item,
-      Leads: 2000 + index * 100,
-    })),
-    customChartColors: ["#32a852", "#fcba03", "orange-600"],
+    customChartColors: ["#32a852", "orange-600"],
   },
 };
 

--- a/src/stories/chart-elements/ScatterChart.stories.tsx
+++ b/src/stories/chart-elements/ScatterChart.stories.tsx
@@ -45,6 +45,12 @@ export const OtherColors: Story = {
   },
 };
 
+export const CustomColors: Story = {
+  args: {
+    customChartColors: ["#32a852", "#fcba03", "orange-600", "blue-400"],
+  },
+};
+
 export const WithCustomValueFormatters: Story = {
   args: {
     valueFormatter: {

--- a/src/stories/spark-elements/SparkAreaChart.stories.tsx
+++ b/src/stories/spark-elements/SparkAreaChart.stories.tsx
@@ -41,6 +41,17 @@ export const OtherColors: Story = {
   args: { colors: ["rose", "purple"] },
 };
 
+export const CustomColors: Story = {
+  args: {
+    categories: ["Leads", "Sales", "Successful Payments"],
+    data: data.map((item, index) => ({
+      ...item,
+      Leads: 2000 + index * 100,
+    })),
+    customChartColors: ["#32a852", "#fcba03", "orange-600"],
+  },
+};
+
 export const NoGradient: Story = {
   args: { showGradient: false },
 };

--- a/src/stories/spark-elements/SparkAreaChart.stories.tsx
+++ b/src/stories/spark-elements/SparkAreaChart.stories.tsx
@@ -43,12 +43,7 @@ export const OtherColors: Story = {
 
 export const CustomColors: Story = {
   args: {
-    categories: ["Leads", "Sales", "Successful Payments"],
-    data: data.map((item, index) => ({
-      ...item,
-      Leads: 2000 + index * 100,
-    })),
-    customChartColors: ["#32a852", "#fcba03", "orange-600"],
+    customChartColors: ["#32a852", "orange-600"],
   },
 };
 

--- a/src/stories/spark-elements/SparkBarChart.stories.tsx
+++ b/src/stories/spark-elements/SparkBarChart.stories.tsx
@@ -51,6 +51,10 @@ export const OtherColors: Story = {
   args: { colors: ["blue", "green"] },
 };
 
+export const CustomColors: Story = {
+  args: { customChartColors: ["#32a852", "orange-600"] },
+};
+
 export const ChangedCategoriesOrder: Story = {
   args: { categories: ["Successful Payments", "Sales"] },
 };

--- a/src/stories/spark-elements/SparkLineChart.stories.tsx
+++ b/src/stories/spark-elements/SparkLineChart.stories.tsx
@@ -35,6 +35,12 @@ export const OtherColors: Story = {
   args: { colors: ["rose", "purple"] },
 };
 
+export const CustomColors: Story = {
+  args: {
+    customChartColors: ["#32a852", "orange-600"],
+  },
+};
+
 export const ChangedCategoriesOrder: Story = {
   args: { categories: ["Successful Payments", "Sales"] },
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -119,7 +119,9 @@ module.exports = {
       pattern:
         /^(fill-(?:slate|gray|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-(?:50|100|200|300|400|500|600|700|800|900|950))$/,
     },
-    ...["[#32a852]", "[#fcba03]", "custom-orange-100"].flatMap((customColor) => [
+
+    // custom colors
+    ...["[#32a852]", "[#fcba03]"].flatMap((customColor) => [
       `bg-${customColor}`,
       `border-${customColor}`,
       `hover:bg-${customColor}`,

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -119,6 +119,20 @@ module.exports = {
       pattern:
         /^(fill-(?:slate|gray|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-(?:50|100|200|300|400|500|600|700|800|900|950))$/,
     },
+    ...["[#32a852]", "[#fcba03]", "custom-orange-100"].flatMap((customColor) => [
+      `bg-${customColor}`,
+      `border-${customColor}`,
+      `hover:bg-${customColor}`,
+      `hover:border-${customColor}`,
+      `hover:text-${customColor}`,
+      `fill-${customColor}`,
+      `ring-${customColor}`,
+      `stroke-${customColor}`,
+      `text-${customColor}`,
+      `ui-selected:bg-${customColor}]`,
+      `ui-selected:border-${customColor}]`,
+      `ui-selected:text-${customColor}`,
+    ]),
   ],
   plugins: [require("@headlessui/tailwindcss")],
 };


### PR DESCRIPTION
**Description**

As described in #565, chart colors are limited to [base colors typed as `Color`](https://github.com/tremorlabs/tremor/blob/1744e4dda4562d17e74947c5e2804578677177ed/src/lib/inputTypes.ts#L35-L58).

For example, this chart will render line colors as expected.

```tsx
<LineChart {...props} colors={["emerald", "indigo"]} />
```

But, this will not work.

```tsx
<LineChart {...props} colors={["#32a852", "custom-color-100"]} />
```

This limitation seems to be due to the complexity in which `className`s are generated under the hood (dynamically at run time and statically at build time via Tailwind theme `safelist`). See [getColorClassNames](https://github.com/tremorlabs/tremor/blob/1744e4dda4562d17e74947c5e2804578677177ed/src/lib/utils.tsx#L73-L107).

**Changes**

This change introduces a new optional `customChartColors` `prop` on chart components to support custom colors (including hex or custom theme colors) on the following components.

- `AreaChart`
- `BarChart`
- `DonutChart`
- `LineChart`
- `ScatterChart`
- `SparkAreaChart`
- `SparkBarChart`
- `SparkLineChart`

Implementation example below.

```tsx
<LineChart {...props} customChartColors={["#32a852", "custom-color-100"]} />
```

The caveat here is that such implementation would require an update to the Tailwind theme `safelist` to ensure Tailwind generates `className`s at build time to mirror `className`s calculated at run time in functions like [getColorClassNames](https://github.com/tremorlabs/tremor/blob/1744e4dda4562d17e74947c5e2804578677177ed/src/lib/utils.tsx#L73-L107). This caveat is somewhat pre-existing, with the reliance on `safelist`. My thought was that we could add a new section to [the theming docs](https://www.tremor.so/docs/getting-started/theming) if using `customChartColors`. Please let me know if I can help here.

Example `safelist` to support the above implementation:

```typescript
safelist: [
  // ..
  // ..
  // custom colors
  ...["[#32a852]", "[#fcba03]"].flatMap((customColor) => [
    `bg-${customColor}`,
    `border-${customColor}`,
    `hover:bg-${customColor}`,
    `hover:border-${customColor}`,
    `hover:text-${customColor}`,
    `fill-${customColor}`,
    `ring-${customColor}`,
    `stroke-${customColor}`,
    `text-${customColor}`,
    `ui-selected:bg-${customColor}]`,
    `ui-selected:border-${customColor}]`,
    `ui-selected:text-${customColor}`,
  ]),
],
```

**Related issue(s)**

- Closes #565 
- Closes #80 
- Related #640 

**What kind of change does this PR introduce?**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**How has This been tested?**

Storybook stories have been added for all components with the new `customChartColors` `prop`.

**The PR fulfills these requirements:**

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It's submitted to the `main` branch
- [x] When resolving a specific issue, it's referenced in the related issue section above
- [x] My change requires a change to the documentation. (Managed by Tremor Team)
- [x] I have added tests to cover my changes
- [x] Check the ["Allow edits from maintainers" option](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) while creating your PR.
- [x] Add refs #XXX or fixes #XXX to the related issue section if your PR refers to or fixes an issue.
- [x] By contributing to Tremor, you confirm that you have read and agreed to Tremor's [CONTRIBUTING.md](https://github.com/tremorlabs/tremor/blob/main/CONTRIBUTING.md) guideline. You also agree that your contributions will be licensed under the [Apache License 2.0](https://github.com/tremorlabs/tremor/blob/main/License) license.
