### PR TITLE
feat: custom chart colors support within existing `colors` `prop`

### DIFF
--- a/src/components/chart-elements/AreaChart/AreaChart.tsx
+++ b/src/components/chart-elements/AreaChart/AreaChart.tsx
@@ -19,7 +19,7 @@ import ChartLegend from "../common/ChartLegend";
 import ChartTooltip from "../common/ChartTooltip";
 import NoData from "../common/NoData";
 import {
-  constructCustomCategoryColors,
+  constructCategoryColors,
   getYAxisDomain,
   hasOnlyOneValueForThisKey,
 } from "../common/utils";
@@ -84,7 +84,7 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>((props, ref) 
   const [legendHeight, setLegendHeight] = useState(60);
   const [activeDot, setActiveDot] = useState<ActiveDot | undefined>(undefined);
   const [activeLegend, setActiveLegend] = useState<string | undefined>(undefined);
-  const categoryColors = constructCustomCategoryColors(categories, colors);
+  const categoryColors = constructCategoryColors(categories, colors);
 
   const yAxisDomain = getYAxisDomain(autoMinValue, minValue, maxValue);
   const hasOnValueChange = !!onValueChange;

--- a/src/components/chart-elements/AreaChart/AreaChart.tsx
+++ b/src/components/chart-elements/AreaChart/AreaChart.tsx
@@ -53,7 +53,6 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>((props, ref) 
     index,
     stack = false,
     colors = themeColorRange,
-    customChartColors = [],
     valueFormatter = defaultValueFormatter,
     startEndOnly = false,
     showXAxis = true,

--- a/src/components/chart-elements/AreaChart/AreaChart.tsx
+++ b/src/components/chart-elements/AreaChart/AreaChart.tsx
@@ -19,7 +19,6 @@ import ChartLegend from "../common/ChartLegend";
 import ChartTooltip from "../common/ChartTooltip";
 import NoData from "../common/NoData";
 import {
-  constructCategoryColors,
   constructCustomCategoryColors,
   getYAxisDomain,
   hasOnlyOneValueForThisKey,
@@ -86,8 +85,7 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>((props, ref) 
   const [legendHeight, setLegendHeight] = useState(60);
   const [activeDot, setActiveDot] = useState<ActiveDot | undefined>(undefined);
   const [activeLegend, setActiveLegend] = useState<string | undefined>(undefined);
-  const categoryColors = constructCategoryColors(categories, colors);
-  const customCategoryColors = constructCustomCategoryColors(categories, customChartColors);
+  const categoryColors = constructCustomCategoryColors(categories, colors);
 
   const yAxisDomain = getYAxisDomain(autoMinValue, minValue, maxValue);
   const hasOnValueChange = !!onValueChange;
@@ -222,9 +220,7 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>((props, ref) 
                       <CustomTooltip
                         payload={payload?.map((payloadItem: any) => ({
                           ...payloadItem,
-                          color: customCategoryColors
-                            ? customCategoryColors.get(payloadItem.dataKey) ?? BaseColors.Gray
-                            : categoryColors.get(payloadItem.dataKey) ?? BaseColors.Gray,
+                          color: categoryColors.get(payloadItem.dataKey) ?? BaseColors.Gray,
                         }))}
                         active={active}
                         label={label}
@@ -236,7 +232,6 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>((props, ref) 
                         label={label}
                         valueFormatter={valueFormatter}
                         categoryColors={categoryColors}
-                        customCategoryColors={customCategoryColors}
                       />
                     )
                 ) : (
@@ -259,7 +254,6 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>((props, ref) 
                       ? (clickedLegendItem: string) => onCategoryClick(clickedLegendItem)
                       : undefined,
                     enableLegendSlider,
-                    customCategoryColors,
                   )
                 }
               />
@@ -273,14 +267,9 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>((props, ref) 
                         getColorClassNames(
                           categoryColors.get(category) ?? BaseColors.Gray,
                           colorPalette.text,
-                          !customCategoryColors ? undefined : customCategoryColors.get(category),
                         ).textColor
                       }
-                      id={
-                        !customCategoryColors
-                          ? categoryColors.get(category)
-                          : customCategoryColors.get(category)
-                      }
+                      id={categoryColors.get(category)}
                       x1="0"
                       y1="0"
                       x2="0"
@@ -301,14 +290,9 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>((props, ref) 
                         getColorClassNames(
                           categoryColors.get(category) ?? BaseColors.Gray,
                           colorPalette.text,
-                          !customCategoryColors ? undefined : customCategoryColors.get(category),
                         ).textColor
                       }
-                      id={
-                        !customCategoryColors
-                          ? categoryColors.get(category)
-                          : customCategoryColors.get(category)
-                      }
+                      id={categoryColors.get(category)}
                       x1="0"
                       y1="0"
                       x2="0"
@@ -331,7 +315,6 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>((props, ref) 
                   getColorClassNames(
                     categoryColors.get(category) ?? BaseColors.Gray,
                     colorPalette.text,
-                    !customCategoryColors ? undefined : customCategoryColors.get(category),
                   ).strokeColor
                 }
                 strokeOpacity={activeDot || (activeLegend && activeLegend !== category) ? 0.3 : 1}
@@ -346,7 +329,6 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>((props, ref) 
                         getColorClassNames(
                           categoryColors.get(dataKey) ?? BaseColors.Gray,
                           colorPalette.text,
-                          !customCategoryColors ? undefined : customCategoryColors.get(dataKey),
                         ).fillColor,
                       )}
                       cx={cx}
@@ -395,7 +377,6 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>((props, ref) 
                           getColorClassNames(
                             categoryColors.get(dataKey) ?? BaseColors.Gray,
                             colorPalette.text,
-                            !customCategoryColors ? undefined : customCategoryColors.get(dataKey),
                           ).fillColor,
                         )}
                       />
@@ -408,11 +389,7 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>((props, ref) 
                 type={curveType}
                 dataKey={category}
                 stroke=""
-                fill={`url(#${
-                  !customCategoryColors
-                    ? categoryColors.get(category)
-                    : customCategoryColors.get(category)
-                })`}
+                fill={`url(#${categoryColors.get(category)})`}
                 strokeWidth={2}
                 strokeLinejoin="round"
                 strokeLinecap="round"

--- a/src/components/chart-elements/BarChart/BarChart.tsx
+++ b/src/components/chart-elements/BarChart/BarChart.tsx
@@ -17,12 +17,7 @@ import BaseChartProps from "../common/BaseChartProps";
 import ChartLegend from "../common/ChartLegend";
 import ChartTooltip from "../common/ChartTooltip";
 import NoData from "../common/NoData";
-import {
-  constructCategoryColors,
-  constructCustomCategoryColors,
-  deepEqual,
-  getYAxisDomain,
-} from "../common/utils";
+import { constructCustomCategoryColors, deepEqual, getYAxisDomain } from "../common/utils";
 
 import { BaseColors, defaultValueFormatter, themeColorRange } from "lib";
 import { AxisDomain } from "recharts/types/util/types";
@@ -73,7 +68,6 @@ const BarChart = React.forwardRef<HTMLDivElement, BarChartProps>((props, ref) =>
     categories = [],
     index,
     colors = themeColorRange,
-    customChartColors = [],
     valueFormatter = defaultValueFormatter,
     layout = "horizontal",
     stack = false,
@@ -103,8 +97,7 @@ const BarChart = React.forwardRef<HTMLDivElement, BarChartProps>((props, ref) =>
   const CustomTooltip = customTooltip;
   const paddingValue = !showXAxis && !showYAxis ? 0 : 20;
   const [legendHeight, setLegendHeight] = useState(60);
-  const categoryColors = constructCategoryColors(categories, colors);
-  const customCategoryColors = constructCustomCategoryColors(categories, customChartColors);
+  const categoryColors = constructCustomCategoryColors(categories, colors);
   const [activeBar, setActiveBar] = React.useState<any | undefined>(undefined);
   const [activeLegend, setActiveLegend] = useState<string | undefined>(undefined);
   const hasOnValueChange = !!onValueChange;
@@ -287,9 +280,7 @@ const BarChart = React.forwardRef<HTMLDivElement, BarChartProps>((props, ref) =>
                       <CustomTooltip
                         payload={payload?.map((payloadItem: any) => ({
                           ...payloadItem,
-                          color: customCategoryColors
-                            ? customCategoryColors.get(payloadItem.dataKey) ?? BaseColors.Gray
-                            : categoryColors.get(payloadItem.dataKey) ?? BaseColors.Gray,
+                          color: categoryColors.get(payloadItem.dataKey) ?? BaseColors.Gray,
                         }))}
                         active={active}
                         label={label}
@@ -301,7 +292,6 @@ const BarChart = React.forwardRef<HTMLDivElement, BarChartProps>((props, ref) =>
                         label={label}
                         valueFormatter={valueFormatter}
                         categoryColors={categoryColors}
-                        customCategoryColors={customCategoryColors}
                       />
                     )
                 ) : (
@@ -324,7 +314,6 @@ const BarChart = React.forwardRef<HTMLDivElement, BarChartProps>((props, ref) =>
                       ? (clickedLegendItem: string) => onCategoryClick(clickedLegendItem)
                       : undefined,
                     enableLegendSlider,
-                    customCategoryColors,
                   )
                 }
               />
@@ -335,7 +324,6 @@ const BarChart = React.forwardRef<HTMLDivElement, BarChartProps>((props, ref) =>
                   getColorClassNames(
                     categoryColors.get(category) ?? BaseColors.Gray,
                     colorPalette.background,
-                    !customCategoryColors ? undefined : customCategoryColors.get(category),
                   ).fillColor,
                   onValueChange ? "cursor-pointer" : "",
                 )}

--- a/src/components/chart-elements/BarChart/BarChart.tsx
+++ b/src/components/chart-elements/BarChart/BarChart.tsx
@@ -17,7 +17,7 @@ import BaseChartProps from "../common/BaseChartProps";
 import ChartLegend from "../common/ChartLegend";
 import ChartTooltip from "../common/ChartTooltip";
 import NoData from "../common/NoData";
-import { constructCustomCategoryColors, deepEqual, getYAxisDomain } from "../common/utils";
+import { constructCategoryColors, deepEqual, getYAxisDomain } from "../common/utils";
 
 import { BaseColors, defaultValueFormatter, themeColorRange } from "lib";
 import { AxisDomain } from "recharts/types/util/types";
@@ -97,7 +97,7 @@ const BarChart = React.forwardRef<HTMLDivElement, BarChartProps>((props, ref) =>
   const CustomTooltip = customTooltip;
   const paddingValue = !showXAxis && !showYAxis ? 0 : 20;
   const [legendHeight, setLegendHeight] = useState(60);
-  const categoryColors = constructCustomCategoryColors(categories, colors);
+  const categoryColors = constructCategoryColors(categories, colors);
   const [activeBar, setActiveBar] = React.useState<any | undefined>(undefined);
   const [activeLegend, setActiveLegend] = useState<string | undefined>(undefined);
   const hasOnValueChange = !!onValueChange;

--- a/src/components/chart-elements/DonutChart/DonutChart.tsx
+++ b/src/components/chart-elements/DonutChart/DonutChart.tsx
@@ -25,8 +25,7 @@ export interface DonutChartProps extends BaseAnimationTimingProps {
   data: any[];
   category?: string;
   index?: string;
-  colors?: Color[];
-  customChartColors?: string[];
+  colors?: string[];
   variant?: DonutChartVariant;
   valueFormatter?: ValueFormatter;
   label?: string;
@@ -80,7 +79,6 @@ const DonutChart = React.forwardRef<HTMLDivElement, DonutChartProps>((props, ref
     category = "value",
     index = "name",
     colors = themeColorRange,
-    customChartColors = [],
     variant = "donut",
     valueFormatter = defaultValueFormatter,
     label,
@@ -162,7 +160,7 @@ const DonutChart = React.forwardRef<HTMLDivElement, DonutChartProps>((props, ref
                 "stroke-tremor-background dark:stroke-dark-tremor-background",
                 onValueChange ? "cursor-pointer" : "cursor-default",
               )}
-              data={parseData(data, colors, customChartColors)}
+              data={parseData(data, colors)}
               cx="50%"
               cy="50%"
               startAngle={90}

--- a/src/components/chart-elements/DonutChart/DonutChart.tsx
+++ b/src/components/chart-elements/DonutChart/DonutChart.tsx
@@ -25,7 +25,7 @@ export interface DonutChartProps extends BaseAnimationTimingProps {
   data: any[];
   category?: string;
   index?: string;
-  colors?: string[];
+  colors?: (Color | string)[];
   variant?: DonutChartVariant;
   valueFormatter?: ValueFormatter;
   label?: string;

--- a/src/components/chart-elements/DonutChart/inputParser.ts
+++ b/src/components/chart-elements/DonutChart/inputParser.ts
@@ -1,7 +1,7 @@
 import { BaseColors, colorPalette, getColorClassNames, sumNumericArray } from "lib";
-import { Color, ValueFormatter } from "../../../lib/inputTypes";
+import { ValueFormatter } from "../../../lib/inputTypes";
 
-export const parseData = (data: any[], colors: Color[], customColors?: string[]) =>
+export const parseData = (data: any[], colors: string[], customColors?: string[]) =>
   data.map((dataPoint: any, idx: number) => {
     const baseColor = idx < colors.length ? colors[idx] : BaseColors.Gray;
     const baseColorCustom =

--- a/src/components/chart-elements/DonutChart/inputParser.ts
+++ b/src/components/chart-elements/DonutChart/inputParser.ts
@@ -1,21 +1,15 @@
 import { BaseColors, colorPalette, getColorClassNames, sumNumericArray } from "lib";
-import { ValueFormatter } from "../../../lib/inputTypes";
+import { Color, ValueFormatter } from "../../../lib/inputTypes";
 
-export const parseData = (data: any[], colors: string[], customColors?: string[]) =>
+export const parseData = (data: any[], colors: (Color | string)[]) =>
   data.map((dataPoint: any, idx: number) => {
     const baseColor = idx < colors.length ? colors[idx] : BaseColors.Gray;
-    const baseColorCustom =
-      customColors && idx < customColors.length ? customColors[idx] : BaseColors.Gray;
     return {
       ...dataPoint,
       // explicitly adding color key if not present for tooltip coloring
       color: baseColor,
-      customColor: baseColorCustom,
-      className: getColorClassNames(
-        baseColor ?? BaseColors.Gray,
-        colorPalette.background,
-        !customColors ? undefined : customColors[idx],
-      ).fillColor,
+      className: getColorClassNames(baseColor ?? BaseColors.Gray, colorPalette.background)
+        .fillColor,
       fill: "",
     };
   });

--- a/src/components/chart-elements/LineChart/LineChart.tsx
+++ b/src/components/chart-elements/LineChart/LineChart.tsx
@@ -18,7 +18,6 @@ import ChartLegend from "../common/ChartLegend";
 import ChartTooltip from "../common/ChartTooltip";
 import NoData from "../common/NoData";
 import {
-  constructCategoryColors,
   constructCustomCategoryColors,
   getYAxisDomain,
   hasOnlyOneValueForThisKey,
@@ -50,7 +49,6 @@ const LineChart = React.forwardRef<HTMLDivElement, LineChartProps>((props, ref) 
     categories = [],
     index,
     colors = themeColorRange,
-    customChartColors = [],
     valueFormatter = defaultValueFormatter,
     startEndOnly = false,
     showXAxis = true,
@@ -81,8 +79,7 @@ const LineChart = React.forwardRef<HTMLDivElement, LineChartProps>((props, ref) 
   const [legendHeight, setLegendHeight] = useState(60);
   const [activeDot, setActiveDot] = useState<ActiveDot | undefined>(undefined);
   const [activeLegend, setActiveLegend] = useState<string | undefined>(undefined);
-  const categoryColors = constructCategoryColors(categories, colors);
-  const customCategoryColors = constructCustomCategoryColors(categories, customChartColors);
+  const categoryColors = constructCustomCategoryColors(categories, colors);
 
   const yAxisDomain = getYAxisDomain(autoMinValue, minValue, maxValue);
   const hasOnValueChange = !!onValueChange;
@@ -218,9 +215,7 @@ const LineChart = React.forwardRef<HTMLDivElement, LineChartProps>((props, ref) 
                       <CustomTooltip
                         payload={payload?.map((payloadItem: any) => ({
                           ...payloadItem,
-                          color: customCategoryColors
-                            ? customCategoryColors.get(payloadItem.dataKey) ?? BaseColors.Gray
-                            : categoryColors.get(payloadItem.dataKey) ?? BaseColors.Gray,
+                          color: categoryColors.get(payloadItem.dataKey) ?? BaseColors.Gray,
                         }))}
                         active={active}
                         label={label}
@@ -232,7 +227,6 @@ const LineChart = React.forwardRef<HTMLDivElement, LineChartProps>((props, ref) 
                         label={label}
                         valueFormatter={valueFormatter}
                         categoryColors={categoryColors}
-                        customCategoryColors={customCategoryColors}
                       />
                     )
                 ) : (
@@ -256,7 +250,6 @@ const LineChart = React.forwardRef<HTMLDivElement, LineChartProps>((props, ref) 
                       ? (clickedLegendItem: string) => onCategoryClick(clickedLegendItem)
                       : undefined,
                     enableLegendSlider,
-                    customCategoryColors,
                   )
                 }
               />
@@ -267,7 +260,6 @@ const LineChart = React.forwardRef<HTMLDivElement, LineChartProps>((props, ref) 
                   getColorClassNames(
                     categoryColors.get(category) ?? BaseColors.Gray,
                     colorPalette.text,
-                    !customCategoryColors ? undefined : customCategoryColors.get(category),
                   ).strokeColor,
                 )}
                 strokeOpacity={activeDot || (activeLegend && activeLegend !== category) ? 0.3 : 1}
@@ -282,7 +274,6 @@ const LineChart = React.forwardRef<HTMLDivElement, LineChartProps>((props, ref) 
                         getColorClassNames(
                           categoryColors.get(dataKey) ?? BaseColors.Gray,
                           colorPalette.text,
-                          !customCategoryColors ? undefined : customCategoryColors.get(category),
                         ).fillColor,
                       )}
                       cx={cx}
@@ -331,7 +322,6 @@ const LineChart = React.forwardRef<HTMLDivElement, LineChartProps>((props, ref) 
                           getColorClassNames(
                             categoryColors.get(dataKey) ?? BaseColors.Gray,
                             colorPalette.text,
-                            !customCategoryColors ? undefined : customCategoryColors.get(dataKey),
                           ).fillColor,
                         )}
                       />

--- a/src/components/chart-elements/LineChart/LineChart.tsx
+++ b/src/components/chart-elements/LineChart/LineChart.tsx
@@ -18,7 +18,7 @@ import ChartLegend from "../common/ChartLegend";
 import ChartTooltip from "../common/ChartTooltip";
 import NoData from "../common/NoData";
 import {
-  constructCustomCategoryColors,
+  constructCategoryColors,
   getYAxisDomain,
   hasOnlyOneValueForThisKey,
 } from "../common/utils";
@@ -79,7 +79,7 @@ const LineChart = React.forwardRef<HTMLDivElement, LineChartProps>((props, ref) 
   const [legendHeight, setLegendHeight] = useState(60);
   const [activeDot, setActiveDot] = useState<ActiveDot | undefined>(undefined);
   const [activeLegend, setActiveLegend] = useState<string | undefined>(undefined);
-  const categoryColors = constructCustomCategoryColors(categories, colors);
+  const categoryColors = constructCategoryColors(categories, colors);
 
   const yAxisDomain = getYAxisDomain(autoMinValue, minValue, maxValue);
   const hasOnValueChange = !!onValueChange;

--- a/src/components/chart-elements/ScatterChart/ScatterChart.tsx
+++ b/src/components/chart-elements/ScatterChart/ScatterChart.tsx
@@ -53,7 +53,7 @@ export interface ScatterChartProps
   size?: string;
   valueFormatter?: ScatterChartValueFormatter;
   sizeRange?: number[];
-  colors?: Color[];
+  colors?: (Color | string)[];
   customChartColors?: string[];
   showOpacity?: boolean;
   startEndOnly?: boolean;

--- a/src/components/chart-elements/ScatterChart/ScatterChart.tsx
+++ b/src/components/chart-elements/ScatterChart/ScatterChart.tsx
@@ -183,7 +183,6 @@ const ScatterChart = React.forwardRef<HTMLDivElement, ScatterChartProps>((props,
 
   const categories = constructCategories(data, category);
   const categoryColors = constructCategoryColors(categories, colors);
-  const customCategoryColors = constructCategoryColors(categories, customChartColors);
 
   //maybe rename getYAxisDomain to getAxisDomain
   const xAxisDomain = getYAxisDomain(autoMinXValue, minXValue, maxXValue);
@@ -287,9 +286,7 @@ const ScatterChart = React.forwardRef<HTMLDivElement, ScatterChartProps>((props,
                       <CustomTooltip
                         payload={payload?.map((payloadItem) => ({
                           ...payloadItem,
-                          color: customCategoryColors
-                            ? customCategoryColors.get(color) ?? BaseColors.Gray
-                            : categoryColors.get(color) ?? BaseColors.Gray,
+                          color: categoryColors.get(color) ?? BaseColors.Gray,
                         }))}
                         active={active}
                         label={color}
@@ -303,7 +300,6 @@ const ScatterChart = React.forwardRef<HTMLDivElement, ScatterChartProps>((props,
                         axis={{ x: x, y: y, size: size }}
                         category={category}
                         categoryColors={categoryColors}
-                        customCategoryColors={customCategoryColors}
                       />
                     );
                   }
@@ -320,20 +316,16 @@ const ScatterChart = React.forwardRef<HTMLDivElement, ScatterChartProps>((props,
                     getColorClassNames(
                       categoryColors.get(cat) ?? BaseColors.Gray,
                       colorPalette.text,
-                      !customCategoryColors ? undefined : customCategoryColors.get(cat),
                     ).fillColor,
                     showOpacity
                       ? getColorClassNames(
                           categoryColors.get(cat) ?? BaseColors.Gray,
                           colorPalette.text,
-                          !customCategoryColors ? undefined : customCategoryColors.get(cat),
                         ).strokeColor
                       : "",
                     onValueChange ? "cursor-pointer" : "",
                   )}
-                  fill={`url(#${
-                    !customCategoryColors ? categoryColors.get(cat) : customCategoryColors.get(cat)
-                  })`}
+                  fill={`url(#${categoryColors.get(cat)})`}
                   fillOpacity={showOpacity ? 0.7 : 1}
                   key={cat}
                   name={cat}
@@ -359,7 +351,6 @@ const ScatterChart = React.forwardRef<HTMLDivElement, ScatterChartProps>((props,
                       ? (clickedLegendItem: string) => onCategoryClick(clickedLegendItem)
                       : undefined,
                     enableLegendSlider,
-                    customCategoryColors,
                   )
                 }
               />

--- a/src/components/chart-elements/ScatterChart/ScatterChart.tsx
+++ b/src/components/chart-elements/ScatterChart/ScatterChart.tsx
@@ -22,7 +22,6 @@ import NoData from "../common/NoData";
 import {
   constructCategories,
   constructCategoryColors,
-  constructCustomCategoryColors,
   deepEqual,
   getYAxisDomain,
 } from "../common/utils";
@@ -184,7 +183,7 @@ const ScatterChart = React.forwardRef<HTMLDivElement, ScatterChartProps>((props,
 
   const categories = constructCategories(data, category);
   const categoryColors = constructCategoryColors(categories, colors);
-  const customCategoryColors = constructCustomCategoryColors(categories, customChartColors);
+  const customCategoryColors = constructCategoryColors(categories, customChartColors);
 
   //maybe rename getYAxisDomain to getAxisDomain
   const xAxisDomain = getYAxisDomain(autoMinXValue, minXValue, maxXValue);

--- a/src/components/chart-elements/ScatterChart/ScatterChart.tsx
+++ b/src/components/chart-elements/ScatterChart/ScatterChart.tsx
@@ -54,7 +54,6 @@ export interface ScatterChartProps
   valueFormatter?: ScatterChartValueFormatter;
   sizeRange?: number[];
   colors?: (Color | string)[];
-  customChartColors?: string[];
   showOpacity?: boolean;
   startEndOnly?: boolean;
   showXAxis?: boolean;
@@ -109,7 +108,6 @@ const ScatterChart = React.forwardRef<HTMLDivElement, ScatterChartProps>((props,
     size,
     category,
     colors = themeColorRange,
-    customChartColors = [],
     showOpacity = false,
     sizeRange = [1, 1000],
     valueFormatter = {

--- a/src/components/chart-elements/ScatterChart/ScatterChartTooltip.tsx
+++ b/src/components/chart-elements/ScatterChart/ScatterChartTooltip.tsx
@@ -59,7 +59,7 @@ export const ChartTooltipRow = ({ value, name }: ChartTooltipRowProps) => (
 
 export interface ScatterChartTooltipProps {
   label: string;
-  categoryColors: Map<string, Color>;
+  categoryColors: Map<string, Color | string>;
   customCategoryColors?: Map<string, string>;
   active: boolean | undefined;
   payload: any;

--- a/src/components/chart-elements/ScatterChart/ScatterChartTooltip.tsx
+++ b/src/components/chart-elements/ScatterChart/ScatterChartTooltip.tsx
@@ -60,7 +60,6 @@ export const ChartTooltipRow = ({ value, name }: ChartTooltipRowProps) => (
 export interface ScatterChartTooltipProps {
   label: string;
   categoryColors: Map<string, Color | string>;
-  customCategoryColors?: Map<string, string>;
   active: boolean | undefined;
   payload: any;
   valueFormatter: ScatterChartValueFormatter;
@@ -76,7 +75,6 @@ const ScatterChartTooltip = ({
   axis,
   category,
   categoryColors,
-  customCategoryColors,
 }: ScatterChartTooltipProps) => {
   if (active && payload) {
     return (
@@ -107,9 +105,6 @@ const ScatterChartTooltip = ({
                   ? categoryColors.get(payload?.[0]?.payload[category]) ?? BaseColors.Blue
                   : BaseColors.Blue,
                 colorPalette.background,
-                !customCategoryColors || !category
-                  ? undefined
-                  : customCategoryColors.get(payload?.[0]?.payload[category]),
               ).bgColor,
               sizing.sm.height,
               sizing.sm.width,

--- a/src/components/chart-elements/common/BaseChartProps.tsx
+++ b/src/components/chart-elements/common/BaseChartProps.tsx
@@ -18,7 +18,6 @@ interface BaseChartProps extends BaseAnimationTimingProps, React.HTMLAttributes<
   categories: string[];
   index: string;
   colors?: (Color | string)[];
-  customChartColors?: string[];
   valueFormatter?: ValueFormatter;
   startEndOnly?: boolean;
   showXAxis?: boolean;

--- a/src/components/chart-elements/common/BaseChartProps.tsx
+++ b/src/components/chart-elements/common/BaseChartProps.tsx
@@ -17,7 +17,7 @@ interface BaseChartProps extends BaseAnimationTimingProps, React.HTMLAttributes<
   data: any[];
   categories: string[];
   index: string;
-  colors?: string[];
+  colors?: (Color | string)[];
   customChartColors?: string[];
   valueFormatter?: ValueFormatter;
   startEndOnly?: boolean;

--- a/src/components/chart-elements/common/BaseChartProps.tsx
+++ b/src/components/chart-elements/common/BaseChartProps.tsx
@@ -17,7 +17,7 @@ interface BaseChartProps extends BaseAnimationTimingProps, React.HTMLAttributes<
   data: any[];
   categories: string[];
   index: string;
-  colors?: Color[];
+  colors?: string[];
   customChartColors?: string[];
   valueFormatter?: ValueFormatter;
   startEndOnly?: boolean;

--- a/src/components/chart-elements/common/ChartLegend.tsx
+++ b/src/components/chart-elements/common/ChartLegend.tsx
@@ -7,7 +7,7 @@ import { Color } from "../../../lib";
 
 const ChartLegend = (
   { payload }: any,
-  categoryColors: Map<string, Color>,
+  categoryColors: Map<string, Color | string>,
   setLegendHeight: React.Dispatch<React.SetStateAction<number>>,
   activeLegend: string | undefined,
   onClick?: (category: string, color: Color, customColor?: string) => void,

--- a/src/components/chart-elements/common/ChartLegend.tsx
+++ b/src/components/chart-elements/common/ChartLegend.tsx
@@ -10,9 +10,8 @@ const ChartLegend = (
   categoryColors: Map<string, Color | string>,
   setLegendHeight: React.Dispatch<React.SetStateAction<number>>,
   activeLegend: string | undefined,
-  onClick?: (category: string, color: Color, customColor?: string) => void,
+  onClick?: (category: string, color: Color | string) => void,
   enableLegendSlider?: boolean,
-  customCategoryColors?: Map<string, string>,
 ) => {
   const legendRef = useRef<HTMLDivElement>(null);
 
@@ -31,11 +30,6 @@ const ChartLegend = (
       <Legend
         categories={filteredPayload.map((entry: any) => entry.value)}
         colors={filteredPayload.map((entry: any) => categoryColors.get(entry.value))}
-        customColors={
-          !customCategoryColors
-            ? undefined
-            : filteredPayload.map((entry: any) => customCategoryColors.get(entry.value))
-        }
         onClickLegendItem={onClick}
         activeLegend={activeLegend}
         enableLegendSlider={enableLegendSlider}

--- a/src/components/chart-elements/common/ChartTooltip.tsx
+++ b/src/components/chart-elements/common/ChartTooltip.tsx
@@ -25,10 +25,9 @@ export interface ChartTooltipRowProps {
   value: string;
   name: string;
   color: Color | string;
-  customColor?: string;
 }
 
-export const ChartTooltipRow = ({ value, name, color, customColor }: ChartTooltipRowProps) => (
+export const ChartTooltipRow = ({ value, name, color }: ChartTooltipRowProps) => (
   <div className="flex items-center justify-between space-x-8">
     <div className="flex items-center space-x-2">
       <span
@@ -39,7 +38,7 @@ export const ChartTooltipRow = ({ value, name, color, customColor }: ChartToolti
           "border-tremor-background shadow-tremor-card",
           // dark
           "dark:border-dark-tremor-background dark:shadow-dark-tremor-card",
-          getColorClassNames(color, colorPalette.background, customColor).bgColor,
+          getColorClassNames(color, colorPalette.background).bgColor,
           sizing.sm.height,
           sizing.sm.width,
           border.md.all,
@@ -78,7 +77,6 @@ export interface ChartTooltipProps {
   payload: any;
   label: string;
   categoryColors: Map<string, Color | string>;
-  customCategoryColors?: Map<string, string>;
   valueFormatter: ValueFormatter;
 }
 
@@ -87,7 +85,6 @@ const ChartTooltip = ({
   payload,
   label,
   categoryColors,
-  customCategoryColors,
   valueFormatter,
 }: ChartTooltipProps) => {
   if (active && payload) {
@@ -127,7 +124,6 @@ const ChartTooltip = ({
               value={valueFormatter(value)}
               name={name}
               color={categoryColors.get(name) ?? BaseColors.Blue}
-              customColor={!customCategoryColors ? undefined : customCategoryColors.get(name)}
             />
           ))}
         </div>

--- a/src/components/chart-elements/common/ChartTooltip.tsx
+++ b/src/components/chart-elements/common/ChartTooltip.tsx
@@ -24,7 +24,7 @@ export const ChartTooltipFrame = ({ children }: { children: React.ReactNode }) =
 export interface ChartTooltipRowProps {
   value: string;
   name: string;
-  color: Color;
+  color: Color | string;
   customColor?: string;
 }
 
@@ -77,7 +77,7 @@ export interface ChartTooltipProps {
   active: boolean | undefined;
   payload: any;
   label: string;
-  categoryColors: Map<string, Color>;
+  categoryColors: Map<string, Color | string>;
   customCategoryColors?: Map<string, string>;
   valueFormatter: ValueFormatter;
 }

--- a/src/components/chart-elements/common/utils.ts
+++ b/src/components/chart-elements/common/utils.ts
@@ -2,20 +2,9 @@ import { Color } from "../../../lib/inputTypes";
 
 export const constructCategoryColors = (
   categories: string[],
-  colors: Color[],
-): Map<string, Color> => {
-  const categoryColors = new Map<string, Color>();
-  categories.forEach((category, idx) => {
-    categoryColors.set(category, colors[idx]);
-  });
-  return categoryColors;
-};
-
-export const constructCustomCategoryColors = (
-  categories: string[],
-  colors: string[],
-): Map<string, string> => {
-  const categoryColors = new Map<string, string>();
+  colors: (Color | string)[],
+): Map<string, Color | string> => {
+  const categoryColors = new Map<string, Color | string>();
   categories.forEach((category, idx) => {
     categoryColors.set(category, colors[idx]);
   });

--- a/src/components/chart-elements/common/utils.ts
+++ b/src/components/chart-elements/common/utils.ts
@@ -14,10 +14,7 @@ export const constructCategoryColors = (
 export const constructCustomCategoryColors = (
   categories: string[],
   colors: string[],
-): Map<string, string> | undefined => {
-  if (!colors.length) {
-    return;
-  }
+): Map<string, string> => {
   const categoryColors = new Map<string, string>();
   categories.forEach((category, idx) => {
     categoryColors.set(category, colors[idx]);

--- a/src/components/spark-elements/SparkAreaChart/SparkAreaChart.tsx
+++ b/src/components/spark-elements/SparkAreaChart/SparkAreaChart.tsx
@@ -5,10 +5,7 @@ import { Area, AreaChart as ReChartsAreaChart, ResponsiveContainer, XAxis } from
 import { BaseColors, colorPalette, getColorClassNames, themeColorRange, tremorTwMerge } from "lib";
 import { CurveType } from "../../../lib/inputTypes";
 import BaseSparkChartProps from "../common/BaseSparkChartProps";
-import {
-  constructCategoryColors,
-  constructCustomCategoryColors,
-} from "components/chart-elements/common/utils";
+import { constructCategoryColors } from "components/chart-elements/common/utils";
 import NoData from "components/chart-elements/common/NoData";
 
 export interface SparkAreaChartProps extends BaseSparkChartProps {
@@ -36,7 +33,7 @@ const AreaChart = React.forwardRef<HTMLDivElement, SparkAreaChartProps>((props, 
     ...other
   } = props;
   const categoryColors = constructCategoryColors(categories, colors);
-  const customCategoryColors = constructCustomCategoryColors(categories, customChartColors);
+  const customCategoryColors = constructCategoryColors(categories, customChartColors);
 
   return (
     <div ref={ref} className={tremorTwMerge("w-28 h-12", className)} {...other}>

--- a/src/components/spark-elements/SparkAreaChart/SparkAreaChart.tsx
+++ b/src/components/spark-elements/SparkAreaChart/SparkAreaChart.tsx
@@ -22,7 +22,6 @@ const AreaChart = React.forwardRef<HTMLDivElement, SparkAreaChartProps>((props, 
     index,
     stack = false,
     colors = themeColorRange,
-    customChartColors = [],
     showAnimation = false,
     animationDuration = 900,
     showGradient = true,
@@ -33,7 +32,6 @@ const AreaChart = React.forwardRef<HTMLDivElement, SparkAreaChartProps>((props, 
     ...other
   } = props;
   const categoryColors = constructCategoryColors(categories, colors);
-  const customCategoryColors = constructCategoryColors(categories, customChartColors);
 
   return (
     <div ref={ref} className={tremorTwMerge("w-28 h-12", className)} {...other}>
@@ -50,14 +48,9 @@ const AreaChart = React.forwardRef<HTMLDivElement, SparkAreaChartProps>((props, 
                         getColorClassNames(
                           categoryColors.get(category) ?? BaseColors.Gray,
                           colorPalette.text,
-                          !customCategoryColors ? undefined : customCategoryColors.get(category),
                         ).textColor
                       }
-                      id={
-                        !customCategoryColors
-                          ? categoryColors.get(category)
-                          : customCategoryColors.get(category)
-                      }
+                      id={categoryColors.get(category)}
                       x1="0"
                       y1="0"
                       x2="0"
@@ -72,14 +65,9 @@ const AreaChart = React.forwardRef<HTMLDivElement, SparkAreaChartProps>((props, 
                         getColorClassNames(
                           categoryColors.get(category) ?? BaseColors.Gray,
                           colorPalette.text,
-                          !customCategoryColors ? undefined : customCategoryColors.get(category),
                         ).textColor
                       }
-                      id={
-                        !customCategoryColors
-                          ? categoryColors.get(category)
-                          : customCategoryColors.get(category)
-                      }
+                      id={categoryColors.get(category)}
                       x1="0"
                       y1="0"
                       x2="0"
@@ -97,7 +85,6 @@ const AreaChart = React.forwardRef<HTMLDivElement, SparkAreaChartProps>((props, 
                   getColorClassNames(
                     categoryColors.get(category) ?? BaseColors.Gray,
                     colorPalette.text,
-                    !customCategoryColors ? undefined : customCategoryColors.get(category),
                   ).strokeColor
                 }
                 strokeOpacity={1}
@@ -107,11 +94,7 @@ const AreaChart = React.forwardRef<HTMLDivElement, SparkAreaChartProps>((props, 
                 type={curveType}
                 dataKey={category}
                 stroke=""
-                fill={`url(#${
-                  !customCategoryColors
-                    ? categoryColors.get(category)
-                    : customCategoryColors.get(category)
-                })`}
+                fill={`url(#${categoryColors.get(category)})`}
                 strokeWidth={2}
                 strokeLinejoin="round"
                 strokeLinecap="round"

--- a/src/components/spark-elements/SparkBarChart/SparkBarChart.tsx
+++ b/src/components/spark-elements/SparkBarChart/SparkBarChart.tsx
@@ -6,10 +6,7 @@ import { Bar, BarChart as ReChartsBarChart, ResponsiveContainer, XAxis } from "r
 
 import { BaseColors, themeColorRange } from "lib";
 import BaseSparkChartProps from "../common/BaseSparkChartProps";
-import {
-  constructCategoryColors,
-  constructCustomCategoryColors,
-} from "components/chart-elements/common/utils";
+import { constructCategoryColors } from "components/chart-elements/common/utils";
 import NoData from "components/chart-elements/common/NoData";
 
 export interface SparkBarChartProps extends BaseSparkChartProps {
@@ -33,7 +30,7 @@ const SparkBarChart = React.forwardRef<HTMLDivElement, SparkBarChartProps>((prop
     ...other
   } = props;
   const categoryColors = constructCategoryColors(categories, colors);
-  const customCategoryColors = constructCustomCategoryColors(categories, customChartColors);
+  const customCategoryColors = constructCategoryColors(categories, customChartColors);
 
   return (
     <div ref={ref} className={tremorTwMerge("w-28 h-12", className)} {...other}>

--- a/src/components/spark-elements/SparkBarChart/SparkBarChart.tsx
+++ b/src/components/spark-elements/SparkBarChart/SparkBarChart.tsx
@@ -20,7 +20,6 @@ const SparkBarChart = React.forwardRef<HTMLDivElement, SparkBarChartProps>((prop
     categories = [],
     index,
     colors = themeColorRange,
-    customChartColors = [],
     stack = false,
     relative = false,
     animationDuration = 900,
@@ -30,7 +29,6 @@ const SparkBarChart = React.forwardRef<HTMLDivElement, SparkBarChartProps>((prop
     ...other
   } = props;
   const categoryColors = constructCategoryColors(categories, colors);
-  const customCategoryColors = constructCategoryColors(categories, customChartColors);
 
   return (
     <div ref={ref} className={tremorTwMerge("w-28 h-12", className)} {...other}>
@@ -48,7 +46,6 @@ const SparkBarChart = React.forwardRef<HTMLDivElement, SparkBarChartProps>((prop
                   getColorClassNames(
                     categoryColors.get(category) ?? BaseColors.Gray,
                     colorPalette.background,
-                    !customCategoryColors ? undefined : customCategoryColors.get(category),
                   ).fillColor,
                 )}
                 key={category}

--- a/src/components/spark-elements/SparkLineChart/SparkLineChart.tsx
+++ b/src/components/spark-elements/SparkLineChart/SparkLineChart.tsx
@@ -5,10 +5,7 @@ import { Line, LineChart as ReChartsLineChart, ResponsiveContainer, XAxis } from
 import { BaseColors, colorPalette, getColorClassNames, themeColorRange, tremorTwMerge } from "lib";
 import { CurveType } from "../../../lib/inputTypes";
 import BaseSparkChartProps from "../common/BaseSparkChartProps";
-import {
-  constructCategoryColors,
-  constructCustomCategoryColors,
-} from "components/chart-elements/common/utils";
+import { constructCategoryColors } from "components/chart-elements/common/utils";
 import NoData from "components/chart-elements/common/NoData";
 
 export interface SparkLineChartProps extends BaseSparkChartProps {
@@ -32,7 +29,7 @@ const SparkLineChart = React.forwardRef<HTMLDivElement, SparkLineChartProps>((pr
     ...other
   } = props;
   const categoryColors = constructCategoryColors(categories, colors);
-  const customCategoryColors = constructCustomCategoryColors(categories, customChartColors);
+  const customCategoryColors = constructCategoryColors(categories, customChartColors);
 
   return (
     <div ref={ref} className={tremorTwMerge("w-28 h-12", className)} {...other}>

--- a/src/components/spark-elements/SparkLineChart/SparkLineChart.tsx
+++ b/src/components/spark-elements/SparkLineChart/SparkLineChart.tsx
@@ -19,7 +19,6 @@ const SparkLineChart = React.forwardRef<HTMLDivElement, SparkLineChartProps>((pr
     categories = [],
     index,
     colors = themeColorRange,
-    customChartColors = [],
     animationDuration = 900,
     showAnimation = false,
     curveType = "linear",
@@ -29,7 +28,6 @@ const SparkLineChart = React.forwardRef<HTMLDivElement, SparkLineChartProps>((pr
     ...other
   } = props;
   const categoryColors = constructCategoryColors(categories, colors);
-  const customCategoryColors = constructCategoryColors(categories, customChartColors);
 
   return (
     <div ref={ref} className={tremorTwMerge("w-28 h-12", className)} {...other}>
@@ -43,7 +41,6 @@ const SparkLineChart = React.forwardRef<HTMLDivElement, SparkLineChartProps>((pr
                   getColorClassNames(
                     categoryColors.get(category) ?? BaseColors.Gray,
                     colorPalette.text,
-                    !customCategoryColors ? undefined : customCategoryColors.get(category),
                   ).strokeColor,
                 )}
                 strokeOpacity={1}

--- a/src/components/spark-elements/common/BaseSparkChartProps.tsx
+++ b/src/components/spark-elements/common/BaseSparkChartProps.tsx
@@ -19,7 +19,6 @@ interface BaseSparkChartProps
   categories: string[];
   index: string;
   colors?: (Color | string)[];
-  customChartColors?: string[];
   noDataText?: string;
 }
 

--- a/src/components/spark-elements/common/BaseSparkChartProps.tsx
+++ b/src/components/spark-elements/common/BaseSparkChartProps.tsx
@@ -18,7 +18,7 @@ interface BaseSparkChartProps
   data: any[];
   categories: string[];
   index: string;
-  colors?: Color[];
+  colors?: (Color | string)[];
   customChartColors?: string[];
   noDataText?: string;
 }

--- a/src/components/text-elements/Legend/Legend.tsx
+++ b/src/components/text-elements/Legend/Legend.tsx
@@ -16,9 +16,9 @@ const makeLegendClassName = makeClassName("Legend");
 
 export interface LegendItemProps {
   name: string;
-  color: Color;
+  color: Color | string;
   customColor?: string;
-  onClick?: (name: string, color: Color, customColor?: string) => void;
+  onClick?: (name: string, color: Color | string) => void;
   activeLegend?: string;
 }
 
@@ -40,7 +40,7 @@ const LegendItem = ({ name, color, customColor, onClick, activeLegend }: LegendI
       )}
       onClick={(e) => {
         e.stopPropagation();
-        onClick?.(name, color, customColor);
+        onClick?.(name, color);
       }}
     >
       <svg
@@ -143,9 +143,8 @@ const ScrollButton = ({ icon, onClick, disabled }: ScrollButtonProps) => {
 
 export interface LegendProps extends React.OlHTMLAttributes<HTMLOListElement> {
   categories: string[];
-  colors?: Color[];
-  customColors?: string[];
-  onClickLegendItem?: (category: string, color: Color) => void;
+  colors?: (Color | string)[];
+  onClickLegendItem?: (category: string, color: Color | string) => void;
   activeLegend?: string;
   enableLegendSlider?: boolean;
 }
@@ -160,7 +159,6 @@ const Legend = React.forwardRef<HTMLOListElement, LegendProps>((props, ref) => {
     categories,
     colors = themeColorRange,
     className,
-    customColors = [],
     onClickLegendItem,
     activeLegend,
     enableLegendSlider = false,
@@ -271,7 +269,6 @@ const Legend = React.forwardRef<HTMLOListElement, LegendProps>((props, ref) => {
             key={`item-${idx}`}
             name={category}
             color={colors[idx]}
-            customColor={!customColors.length ? undefined : customColors[idx]}
             onClick={onClickLegendItem}
             activeLegend={activeLegend}
           />

--- a/src/lib/inputTypes.ts
+++ b/src/lib/inputTypes.ts
@@ -32,7 +32,7 @@ const sizeValues = ["xs", "sm", "md", "lg", "xl"] as const;
 
 export type Size = (typeof sizeValues)[number];
 
-const colorValues = [
+export const colorValues = [
   "slate",
   "gray",
   "zinc",

--- a/src/lib/inputTypes.ts
+++ b/src/lib/inputTypes.ts
@@ -58,6 +58,7 @@ export const colorValues = [
 ] as const;
 
 export type Color = (typeof colorValues)[number];
+export const getIsBaseColor = (color: string) => colorValues.includes(color as Color);
 
 const justifyContentValues = ["start", "end", "center", "between", "around", "evenly"] as const;
 export type JustifyContent = (typeof justifyContentValues)[number];

--- a/src/lib/inputTypes.ts
+++ b/src/lib/inputTypes.ts
@@ -58,7 +58,7 @@ export const colorValues = [
 ] as const;
 
 export type Color = (typeof colorValues)[number];
-export const getIsBaseColor = (color: string) => colorValues.includes(color as Color);
+export const getIsBaseColor = (color: Color | string) => colorValues.includes(color as Color);
 
 const justifyContentValues = ["start", "end", "center", "between", "around", "evenly"] as const;
 export type JustifyContent = (typeof justifyContentValues)[number];

--- a/src/lib/utils.tsx
+++ b/src/lib/utils.tsx
@@ -72,7 +72,7 @@ interface ColorClassNames {
 
 /**
  * Returns boolean based on a determination that a color should be considered an "arbitrary"
- * Tailwind class.
+ * Tailwind CSS class.
  * @see {@link https://tailwindcss.com/docs/background-color#arbitrary-values | Tailwind CSS docs}
  */
 const getIsArbitraryColor = (color: Color | string) =>

--- a/src/lib/utils.tsx
+++ b/src/lib/utils.tsx
@@ -1,5 +1,6 @@
 import { DeltaTypes } from "./constants";
-import { Color, ValueFormatter } from "./inputTypes";
+import { colorValues, ValueFormatter } from "./inputTypes";
+import type { Color } from "./inputTypes";
 
 export const mapInputsToDeltaType = (deltaType: string, isIncreasePositive: boolean): string => {
   if (isIncreasePositive || deltaType === DeltaTypes.Unchanged) {
@@ -70,23 +71,10 @@ interface ColorClassNames {
   fillColor: string;
 }
 
-export function getColorClassNames(
-  color: Color | "white" | "black" | "transparent",
-  shade?: number,
-  customColor?: string,
-): ColorClassNames {
-  if (
-    color === "white" ||
-    color === "black" ||
-    color === "transparent" ||
-    !!customColor ||
-    !shade
-  ) {
-    const unshadedColor = !customColor
-      ? color
-      : customColor.includes("#")
-      ? `[${customColor}]`
-      : customColor;
+export function getColorClassNames(color: string, shade?: number, _?: string): ColorClassNames {
+  const isBaseColor = colorValues.includes(color as Color);
+  if (color === "white" || color === "black" || color === "transparent" || !shade || !isBaseColor) {
+    const unshadedColor = color.includes("#") ? `[${color}]` : color;
     return {
       bgColor: `bg-${unshadedColor}`,
       hoverBgColor: `hover:bg-${unshadedColor}`,

--- a/src/lib/utils.tsx
+++ b/src/lib/utils.tsx
@@ -1,5 +1,5 @@
 import { DeltaTypes } from "./constants";
-import { getIsBaseColor, ValueFormatter } from "./inputTypes";
+import { Color, getIsBaseColor, ValueFormatter } from "./inputTypes";
 
 export const mapInputsToDeltaType = (deltaType: string, isIncreasePositive: boolean): string => {
   if (isIncreasePositive || deltaType === DeltaTypes.Unchanged) {
@@ -70,7 +70,11 @@ interface ColorClassNames {
   fillColor: string;
 }
 
-export function getColorClassNames(color: string, shade?: number, _?: string): ColorClassNames {
+export function getColorClassNames(
+  color: Color | string,
+  shade?: number,
+  _?: string,
+): ColorClassNames {
   const isBaseColor = getIsBaseColor(color);
   if (color === "white" || color === "black" || color === "transparent" || !shade || !isBaseColor) {
     const unshadedColor = color.includes("#") ? `[${color}]` : color;

--- a/src/lib/utils.tsx
+++ b/src/lib/utils.tsx
@@ -78,11 +78,7 @@ interface ColorClassNames {
 const getIsArbitraryColor = (color: Color | string) =>
   color.includes("#") || color.includes("--") || color.includes("rgb");
 
-export function getColorClassNames(
-  color: Color | string,
-  shade?: number,
-  _?: string,
-): ColorClassNames {
+export function getColorClassNames(color: Color | string, shade?: number): ColorClassNames {
   const isBaseColor = getIsBaseColor(color);
   if (color === "white" || color === "black" || color === "transparent" || !shade || !isBaseColor) {
     const unshadedColor = !getIsArbitraryColor(color) ? color : `[${color}]`;

--- a/src/lib/utils.tsx
+++ b/src/lib/utils.tsx
@@ -1,6 +1,5 @@
 import { DeltaTypes } from "./constants";
-import { colorValues, ValueFormatter } from "./inputTypes";
-import type { Color } from "./inputTypes";
+import { getIsBaseColor, ValueFormatter } from "./inputTypes";
 
 export const mapInputsToDeltaType = (deltaType: string, isIncreasePositive: boolean): string => {
   if (isIncreasePositive || deltaType === DeltaTypes.Unchanged) {
@@ -72,7 +71,7 @@ interface ColorClassNames {
 }
 
 export function getColorClassNames(color: string, shade?: number, _?: string): ColorClassNames {
-  const isBaseColor = colorValues.includes(color as Color);
+  const isBaseColor = getIsBaseColor(color);
   if (color === "white" || color === "black" || color === "transparent" || !shade || !isBaseColor) {
     const unshadedColor = color.includes("#") ? `[${color}]` : color;
     return {

--- a/src/lib/utils.tsx
+++ b/src/lib/utils.tsx
@@ -70,6 +70,14 @@ interface ColorClassNames {
   fillColor: string;
 }
 
+/**
+ * Returns boolean based on a determination that a color should be considered an "arbitrary"
+ * Tailwind class.
+ * @see {@link https://tailwindcss.com/docs/background-color#arbitrary-values | Tailwind CSS docs}
+ */
+const getIsArbitraryColor = (color: Color | string) =>
+  color.includes("#") || color.includes("--") || color.includes("rgb");
+
 export function getColorClassNames(
   color: Color | string,
   shade?: number,
@@ -77,7 +85,7 @@ export function getColorClassNames(
 ): ColorClassNames {
   const isBaseColor = getIsBaseColor(color);
   if (color === "white" || color === "black" || color === "transparent" || !shade || !isBaseColor) {
-    const unshadedColor = color.includes("#") ? `[${color}]` : color;
+    const unshadedColor = !getIsArbitraryColor(color) ? color : `[${color}]`;
     return {
       bgColor: `bg-${unshadedColor}`,
       hoverBgColor: `hover:bg-${unshadedColor}`,

--- a/src/stories/chart-elements/AreaChart.stories.tsx
+++ b/src/stories/chart-elements/AreaChart.stories.tsx
@@ -62,7 +62,7 @@ export const OtherColors: Story = {
 
 export const CustomColors: Story = {
   args: {
-    customChartColors: ["#32a852", "orange-600"],
+    colors: ["#32a852", "orange-600"],
   },
 };
 

--- a/src/stories/chart-elements/BarChart.stories.tsx
+++ b/src/stories/chart-elements/BarChart.stories.tsx
@@ -92,7 +92,7 @@ export const OtherColors: Story = {
 
 export const CustomColors: Story = {
   args: {
-    customChartColors: ["#32a852", "orange-600"],
+    colors: ["#32a852", "orange-600"],
   },
 };
 

--- a/src/stories/chart-elements/DonutChart.stories.tsx
+++ b/src/stories/chart-elements/DonutChart.stories.tsx
@@ -79,7 +79,7 @@ export const OtherColors: Story = {
 
 export const CustomColors: Story = {
   args: {
-    customChartColors: ["#32a852", "#fcba03", "orange-600", "blue-400", "violet-400", "rose-400"],
+    colors: ["#32a852", "#fcba03", "orange-600", "blue-400", "violet-400", "rose-400"],
   },
 };
 

--- a/src/stories/chart-elements/LineChart.stories.tsx
+++ b/src/stories/chart-elements/LineChart.stories.tsx
@@ -56,7 +56,7 @@ export const OtherColors: Story = {
 
 export const CustomColors: Story = {
   args: {
-    customChartColors: ["#32a852", "orange-600"],
+    colors: ["#32a852", "orange-600"],
   },
 };
 

--- a/src/stories/chart-elements/ScatterChart.stories.tsx
+++ b/src/stories/chart-elements/ScatterChart.stories.tsx
@@ -47,7 +47,7 @@ export const OtherColors: Story = {
 
 export const CustomColors: Story = {
   args: {
-    customChartColors: ["#32a852", "#fcba03", "orange-600", "blue-400"],
+    colors: ["#32a852", "#fcba03", "orange-600", "blue-400"],
   },
 };
 

--- a/src/stories/spark-elements/SparkAreaChart.stories.tsx
+++ b/src/stories/spark-elements/SparkAreaChart.stories.tsx
@@ -43,7 +43,7 @@ export const OtherColors: Story = {
 
 export const CustomColors: Story = {
   args: {
-    customChartColors: ["#32a852", "orange-600"],
+    colors: ["#32a852", "orange-600"],
   },
 };
 

--- a/src/stories/spark-elements/SparkBarChart.stories.tsx
+++ b/src/stories/spark-elements/SparkBarChart.stories.tsx
@@ -52,7 +52,7 @@ export const OtherColors: Story = {
 };
 
 export const CustomColors: Story = {
-  args: { customChartColors: ["#32a852", "orange-600"] },
+  args: { colors: ["#32a852", "orange-600"] },
 };
 
 export const ChangedCategoriesOrder: Story = {

--- a/src/stories/spark-elements/SparkLineChart.stories.tsx
+++ b/src/stories/spark-elements/SparkLineChart.stories.tsx
@@ -37,7 +37,7 @@ export const OtherColors: Story = {
 
 export const CustomColors: Story = {
   args: {
-    customChartColors: ["#32a852", "orange-600"],
+    colors: ["#32a852", "orange-600"],
   },
 };
 


### PR DESCRIPTION
**Description**

This change is refactor of #836 to provide support for custom colors, but instead of the additive `customChartColors` `prop` - this ports functionality to the existing `colors` `prop`.

With this change, the `colors` `prop` can accept custom colors or tremor base colors (`(Color | string)[]`). `customChartColors` is removed in this change.

**Example Usage**

```tsx
<LineChart
  {...props}
  colors={[
    // now supports any mix of tremor base colors...
    'emerald',
    'indigo',

    // ... and custom colors
    '#32a852',
    'custom-color-100',
  ]}
/>
```

Example `safelist` needed in Tailwind config to support the above implementation:

```typescript
safelist: [
  // ..
  // ..
  // custom colors
  ...["[#32a852]", "custom-color-100"].flatMap((customColor) => [
    `bg-${customColor}`,
    `border-${customColor}`,
    `hover:bg-${customColor}`,
    `hover:border-${customColor}`,
    `hover:text-${customColor}`,
    `fill-${customColor}`,
    `ring-${customColor}`,
    `stroke-${customColor}`,
    `text-${customColor}`,
    `ui-selected:bg-${customColor}`,
    `ui-selected:border-${customColor}`,
    `ui-selected:text-${customColor}`,
  ]),
],
```

**Updated Components**

- `AreaChart`
- `BarChart`
- `DonutChart`
- `LineChart`
- `ScatterChart`
- `SparkAreaChart`
- `SparkBarChart`
- `SparkLineChart`

**Related issues and PRs**

- Related #836
- Related #565 
- Related #80 
- Related #640 

**What kind of change does this PR introduce?**

Although this change updates the existing `colors` `prop`, the functionality is additive and doesn't break existing behavior.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**How has This been tested?**

Storybook stories have been added for all components demonstrating new support of custom colors in the `colors` `prop`.

**The PR fulfills these requirements:**

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It's submitted to the `main` branch
- [x] When resolving a specific issue, it's referenced in the related issue section above
- [x] My change requires a change to the documentation. (Managed by Tremor Team)
- [x] I have added tests to cover my changes
- [x] Check the ["Allow edits from maintainers" option](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) while creating your PR.
- [x] Add refs #XXX or fixes #XXX to the related issue section if your PR refers to or fixes an issue.
- [x] By contributing to Tremor, you confirm that you have read and agreed to Tremor's [CONTRIBUTING.md](https://github.com/tremorlabs/tremor/blob/main/CONTRIBUTING.md) guideline. You also agree that your contributions will be licensed under the [Apache License 2.0](https://github.com/tremorlabs/tremor/blob/main/License) license.
