### PR TITLE
fix: text-input can't blur on type password (#864)

### DIFF
--- a/src/components/input-elements/BaseInput.tsx
+++ b/src/components/input-elements/BaseInput.tsx
@@ -49,14 +49,13 @@ const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>((props, ref
 
   const hasSelection = hasValue(value || defaultValue);
 
-  const handleFocusChange = (isFocused: boolean) => {
-    if (isFocused === false) {
-      inputRef.current?.blur();
-    } else {
+  React.useEffect(() => {
+    if (isFocused) {
       inputRef.current?.focus();
+    } else {
+      inputRef.current?.blur();
     }
-    setIsFocused(isFocused);
-  };
+  }, [isFocused]);
 
   React.useEffect(() => {
     // If the autoFocus prop is true, then set the isFocused state to true
@@ -92,14 +91,11 @@ const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>((props, ref
         )}
         onClick={() => {
           if (!disabled) {
-            handleFocusChange(true);
+            setIsFocused(true);
           }
         }}
         onFocus={() => {
-          handleFocusChange(true);
-        }}
-        onBlur={() => {
-          handleFocusChange(false);
+          setIsFocused(true);
         }}
       >
         {Icon ? (
@@ -153,6 +149,9 @@ const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>((props, ref
             className={tremorTwMerge(makeInputClassName("toggleButton"), "mr-2")}
             type="button"
             onClick={() => toggleIsPasswordVisible()}
+            onBlur={() => {
+              setIsFocused(false);
+            }}
           >
             {isPasswordVisible ? (
               <EyeOffIcon


### PR DESCRIPTION
**Description**
As stated in #864 pressing the Tab key on TextInput is supposed to move to the next item but if the input type is password it won't.
in this PR I've removed the function `handleFocusChange` and replaced it with a `useEffect` that listens for changed on `isFocused` and choose whether to focus the input item or not.
I've let the button for showing password be focused for accessibility reasons.

**Related issue(s)**
Fixes #864 

**What kind of change does this PR introduce?** (check at least one)

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] New Feature (BREAKING CHANGE which adds functionality)
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**How has this been tested?**

Clicked on an input with type password and then pressed Tab key and it focused on the show password icon

**Screenshots (if appropriate):**

**The PR fulfils these requirements:**

- [X] It's submitted to the `main` branch
- [X] When resolving a specific issue, it's referenced in the related issue section above
- [ ] My change requires a change to the documentation. (Managed by Tremor Team)
- [ ] I have added tests to cover my changes
- [X] Check the ["Allow edits from maintainers" option](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) while creating your PR.
- [X] Add refs #XXX or fixes #XXX to the related issue section if your PR refers to or fixes an issue.
- [X] By contributing to Tremor, you confirm that you have read and agreed to Tremor's [CONTRIBUTING.md](https://github.com/tremorlabs/tremor/blob/main/CONTRIBUTING.md) guideline. You also agree that your contributions will be licensed under the [Apache License 2.0](https://github.com/tremorlabs/tremor/blob/main/License) license.
