### PR TITLE
fix: padding

### DIFF
--- a/src/components/input-elements/SearchSelect/SearchSelect.tsx
+++ b/src/components/input-elements/SearchSelect/SearchSelect.tsx
@@ -113,7 +113,7 @@ const SearchSelect = React.forwardRef<HTMLDivElement, SearchSelectProps>((props,
                 "border-tremor-border shadow-tremor-input focus:border-tremor-brand-subtle focus:ring-tremor-brand-muted",
                 // dark
                 "dark:border-dark-tremor-border dark:shadow-dark-tremor-input dark:focus:border-dark-tremor-brand-subtle dark:focus:ring-dark-tremor-brand-muted",
-                Icon ? "p-10 -ml-0.5" : "pl-3",
+                Icon ? "pl-10" : "pl-3",
                 disabled
                   ? "placeholder:text-tremor-content-subtle dark:placeholder:text-tremor-content-subtle"
                   : "placeholder:text-tremor-content dark:placeholder:text-tremor-content",

--- a/src/components/input-elements/Select/Select.tsx
+++ b/src/components/input-elements/Select/Select.tsx
@@ -78,7 +78,7 @@ const Select = React.forwardRef<HTMLDivElement, SelectProps>((props, ref) => {
               "border-tremor-border shadow-tremor-input focus:border-tremor-brand-subtle focus:ring-tremor-brand-muted",
               // dark
               "dark:border-dark-tremor-border dark:shadow-dark-tremor-input dark:focus:border-dark-tremor-brand-subtle dark:focus:ring-dark-tremor-brand-muted",
-              Icon ? "p-10 -ml-0.5" : "pl-3",
+              Icon ? "pl-10" : "pl-3",
               getSelectButtonColors(hasValue(value), disabled),
             )}
           >


### PR DESCRIPTION
<!--
Please make sure to read the Contribution Guidelines:
https://github.com/tremorlabs/tremor/blob/main/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
**Description**

This PR fixes a padding issue when setting an Icon to Select and SearchSelect

**Related issue(s)**

* Closes #910
* * Closes #912

**What kind of change does this PR introduce?** (check at least one)
<!-- (Update "[ ]" to "[x]" to check a box) -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] New Feature (BREAKING CHANGE which adds functionality)
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**How has this been tested?**

Storybook

**Screenshots (if appropriate):**


**The PR fulfils these requirements:**

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the related issue section above
- [ ] My change requires a change to the documentation. (Managed by Tremor Team)
- [ ] I have added tests to cover my changes
- [ ] Check the ["Allow edits from maintainers" option](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) while creating your PR.
- [x] Add refs #XXX or fixes #XXX to the related issue section if your PR refers to or fixes an issue.
- [x] By contributing to Tremor, you confirm that you have read and agreed to Tremor's [CONTRIBUTING.md](https://github.com/tremorlabs/tremor/blob/main/CONTRIBUTING.md) guideline. You also agree that your contributions will be licensed under the [Apache License 2.0](https://github.com/tremorlabs/tremor/blob/main/License) license.
