### PR TITLE
feat: Added subtitle theme token

### DIFF
--- a/src/components/text-elements/Subtitle/Subtitle.tsx
+++ b/src/components/text-elements/Subtitle/Subtitle.tsx
@@ -15,6 +15,7 @@ const Subtitle = React.forwardRef<HTMLParagraphElement, SubtitleProps>((props, r
     <p
       ref={ref}
       className={tremorTwMerge(
+        "text-tremor-subtitle",
         color
           ? getColorClassNames(color, colorPalette.lightText).textColor
           : "text-tremor-content-subtle dark:text-dark-tremor-content-subtle",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -88,7 +88,7 @@ module.exports = {
       fontSize: {
         "tremor-label": ["0.75rem"],
         "tremor-default": ["0.875rem", { lineHeight: "1.25rem" }],
-        "tremor-subtitle": ["0.875rem", { lineHeight: "1.5rem" }],
+        "tremor-subtitle": ["1rem", { lineHeight: "1.5rem" }],
         "tremor-title": ["1.125rem", { lineHeight: "1.75rem" }],
         "tremor-metric": ["1.875rem", { lineHeight: "2.25rem" }],
       },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -88,6 +88,7 @@ module.exports = {
       fontSize: {
         "tremor-label": ["0.75rem"],
         "tremor-default": ["0.875rem", { lineHeight: "1.25rem" }],
+        "tremor-subtitle": ["0.875rem", { lineHeight: "1.5rem" }],
         "tremor-title": ["1.125rem", { lineHeight: "1.75rem" }],
         "tremor-metric": ["1.875rem", { lineHeight: "2.25rem" }],
       },


### PR DESCRIPTION
**Description**
This feature adds the option to define custom font size and line height for Subtitle components using theme tokens in `tailwind.config.js`.

**Related issue**
Closes: [[Feature]: Theme token for Subtitle font size #941](https://github.com/tremorlabs/tremor/issues/941)

**What kind of change does this PR introduce?**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [] New Feature (non-breaking change which adds functionality)
- [x] New Feature (BREAKING CHANGE which adds functionality)
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?**

- [x] Yes
- [] No

**How has this been tested?:**
- Jest test ran successfully
- Storyboard

**The PR fulfils these requirements:**

- [x] It's submitted to the `main` branch
- [x] When resolving a specific issue, it's referenced in the related issue section above
- [x] My change requires a change to the documentation. (Managed by Tremor Team)
- [ ] I have added tests to cover my changes
- [x] Check the ["Allow edits from maintainers" option](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) while creating your PR.
- [x] Add refs #XXX or fixes #XXX to the related issue section if your PR refers to or fixes an issue.
- [x] By contributing to Tremor, you confirm that you have read and agreed to Tremor's [CONTRIBUTING.md](https://github.com/tremorlabs/tremor/blob/main/CONTRIBUTING.md) guideline. You also agree that your contributions will be licensed under the [Apache License 2.0](https://github.com/tremorlabs/tremor/blob/main/License) license.
