### PR TITLE
feat: issue #966 - adding more control to Props

### DIFF
--- a/src/components/util-elements/Tooltip/Tooltip.tsx
+++ b/src/components/util-elements/Tooltip/Tooltip.tsx
@@ -76,29 +76,43 @@ export interface TooltipProps {
   getFloatingProps: (
     userProps?: React.HTMLProps<HTMLElement> | undefined,
   ) => Record<string, unknown>;
+  darkTheme?: boolean;  // for dark theme, light default
+  preventWrap?: boolean;  // prevent text wrapping
+  width?: string | number;  // setting width by string or number
 }
 
-const Tooltip = ({ text, open, x, y, refs, strategy, getFloatingProps }: TooltipProps) => {
+
+const Tooltip = ({
+                   text,
+                   open,
+                   x,
+                   y,
+                   refs,
+                   strategy,
+                   getFloatingProps,
+                   darkTheme = false,
+                   preventWrap = false,
+                   width = 'auto'  // Default width set to 'auto'
+                 }: TooltipProps) => {
   return open && text ? (
-    <div
-      className={tremorTwMerge(
-        // common
-        "max-w-xs text-sm z-20 rounded-tremor-default opacity-100 px-2.5 py-1 whitespace-nowrap",
-        // light
-        "text-white bg-tremor-background-emphasis",
-        // dark
-        "text-white dark:bg-dark-tremor-background-subtle",
-      )}
-      ref={refs.setFloating}
-      style={{
-        position: strategy,
-        top: y ?? 0,
-        left: x ?? 0,
-      }}
-      {...getFloatingProps()}
-    >
-      {text}
-    </div>
+      <div
+          className={tremorTwMerge(
+              "text-sm z-20 rounded-tremor-default opacity-100 px-2.5 py-1",
+              "overflow-hidden",
+              preventWrap ? "whitespace-nowrap" : "",  // Apply based on preventWrap
+              darkTheme ? "text-white dark:bg-dark-tremor-background-subtle" : "text-white bg-tremor-background-emphasis",  // Apply theme based on darkTheme
+          )}
+          ref={refs.setFloating}
+          style={{
+            position: strategy,
+            top: y ?? 0,
+            left: x ?? 0,
+            width: typeof width === 'number' ? `${width}px` : width  // Set width
+          }}
+          {...getFloatingProps()}
+      >
+        {text}
+      </div>
   ) : null;
 };
 


### PR DESCRIPTION
<!--
Please make sure to read the Contribution Guidelines:
https://github.com/tremorlabs/tremor/blob/main/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
**Description**

<!--- Describe your changes in detail -->

**Related issue(s)**

- Fix for https://github.com/tremorlabs/tremor/issues/966
- - hiding overflow text for tooltip
- Enhancement to allow users option to use text wrapping for the tooltip
- Enhancement to allow users option to set their tooltip width with number or string (ex: "300px")
- Enhancement to allow users option to select dark or light theme for tooltip

**What kind of change does this PR introduce?** (check at least one)

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ x] New Feature (non-breaking change which adds functionality)
- [ ] New Feature (BREAKING CHANGE which adds functionality)
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `main` branch
- [x] When resolving a specific issue, it's referenced in the related issue section above
- [x] My change requires a change to the documentation. (Managed by Tremor Team)
- [ ] I have added tests to cover my changes
- [x] Check the ["Allow edits from maintainers" option](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) while creating your PR.
- [x] Add refs #XXX or fixes #XXX to the related issue section if your PR refers to or fixes an issue.
- [x] By contributing to Tremor, you confirm that you have read and agreed to Tremor's [CONTRIBUTING.md](https://github.com/tremorlabs/tremor/blob/main/CONTRIBUTING.md) guideline. You also agree that your contributions will be licensed under the [Apache License 2.0](https://github.com/tremorlabs/tremor/blob/main/License) license.
