### PR TITLE
fix: tab focus

### DIFF
--- a/src/components/input-elements/Tabs/Tab.tsx
+++ b/src/components/input-elements/Tabs/Tab.tsx
@@ -56,7 +56,7 @@ const Tab = React.forwardRef<HTMLButtonElement, TabProps>((props, ref) => {
       className={tremorTwMerge(
         makeTabClassName("root"),
         // common
-        "flex whitespace-nowrap truncate max-w-xs outline-none focus:ring-0 text-tremor-default transition duration-100",
+        "flex whitespace-nowrap truncate max-w-xs outline-none focus:ring text-tremor-default transition duration-100",
         // brand
         color
           ? getColorClassNames(color, colorPalette.text).selectTextColor


### PR DESCRIPTION
<!--
Please make sure to read the Contribution Guidelines:
https://github.com/tremorlabs/tremor/blob/main/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
**Description**

Changed the class from `focus:ring-0` to `focus:ring` to improve keyboard navigation and accessibility in the `Tab` component.

Another class idea I had was `focus:ring-1 rounded-t`, which would have slightly softer features

**Related issue(s)**

#305 

**What kind of change does this PR introduce?** (check at least one)
<!-- (Update "[ ]" to "[x]" to check a box) -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] New Feature (BREAKING CHANGE which adds functionality)
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**How has this been tested?**

<!--- Please describe how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Visual UI/UX test using storybook `npm run storybook`

**Screenshots (if appropriate):**

MacBook Pro Sonoma 14.2.1 
Chrome Version 123.0.6312.87 (Official Build) (arm64)

<img width="873" alt="Screenshot 2024-04-02 at 10 21 25 PM" src="https://github.com/tremorlabs/tremor/assets/22807629/ceaff718-b6c2-42f1-a3da-59beeb0d4ca3">


**The PR fulfils these requirements:**

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It's submitted to the `main` branch
- [x] When resolving a specific issue, it's referenced in the related issue section above
- [ ] My change requires a change to the documentation. (Managed by Tremor Team)
- [ ] I have added tests to cover my changes
- [x] Check the ["Allow edits from maintainers" option](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) while creating your PR.
- [x] Add refs #XXX or fixes #XXX to the related issue section if your PR refers to or fixes an issue.
- [x] By contributing to Tremor, you confirm that you have read and agreed to Tremor's [CONTRIBUTING.md](https://github.com/tremorlabs/tremor/blob/main/CONTRIBUTING.md) guideline. You also agree that your contributions will be licensed under the [Apache License 2.0](https://github.com/tremorlabs/tremor/blob/main/License) license.
