### PR TITLE
feat: CategoryBar now supports values more than 100 or less than 100 (while more than 1)

### DIFF
--- a/src/components/vis-elements/BarList/BarList.tsx
+++ b/src/components/vis-elements/BarList/BarList.tsx
@@ -111,8 +111,9 @@ function BarListInner<T>(props: BarListProps<T>, ref: React.ForwardedRef<HTMLDiv
                   onValueChange && !(item.color || color)
                     ? "group-hover:bg-tremor-brand-subtle/30 group-hover:dark:bg-dark-tremor-brand-subtle/70"
                     : "",
-                  // margin and duration
+                  // margin
                   index === sortedData.length - 1 ? "mb-0" : "",
+                  // duration
                   showAnimation ? "duration-500" : "",
                 )}
                 style={{ width: `${widths[index]}%`, transition: showAnimation ? "all 1s" : "" }}

--- a/src/components/vis-elements/CategoryBar/CategoryBar.tsx
+++ b/src/components/vis-elements/CategoryBar/CategoryBar.tsx
@@ -57,7 +57,9 @@ const BarLabels = ({ values }: { values: number[] }) => {
           (widthPercentage >= 0.1 * sumValues || sumConsecutiveHiddenLabels >= 0.09 * sumValues) &&
           sumValues - prefixSum >= 0.15 * sumValues &&
           prefixSum >= 0.1 * sumValues;
-        sumConsecutiveHiddenLabels = showLabel ? 0 : (sumConsecutiveHiddenLabels += widthPercentage);
+        sumConsecutiveHiddenLabels = showLabel
+          ? 0
+          : (sumConsecutiveHiddenLabels += widthPercentage);
 
         const widthPositionLeft = getPositionLeft(widthPercentage, sumValues);
 

--- a/src/components/vis-elements/CategoryBar/CategoryBar.tsx
+++ b/src/components/vis-elements/CategoryBar/CategoryBar.tsx
@@ -36,7 +36,7 @@ const getPositionLeft = (value: number | undefined, maxValue: number): number =>
   value ? (value / maxValue) * 100 : 0;
 
 const BarLabels = ({ values }: { values: number[] }) => {
-  const sumValues = sumNumericArray(values);
+  const sumValues = useMemo(() => sumNumericArray(values), [values]);
   let prefixSum = 0;
   let sumConsecutveHiddenLabels = 0;
   return (
@@ -104,7 +104,10 @@ const CategoryBar = React.forwardRef<HTMLDivElement, CategoryBarProps>((props, r
     ...other
   } = props;
 
-  const markerBgColor = getMarkerBgColor(markerValue, values, colors);
+  const markerBgColor = useMemo(
+    () => getMarkerBgColor(markerValue, values, colors),
+    [markerValue, values, colors],
+  );
 
   const { tooltipProps, getReferenceProps } = useTooltip();
 

--- a/src/components/vis-elements/CategoryBar/CategoryBar.tsx
+++ b/src/components/vis-elements/CategoryBar/CategoryBar.tsx
@@ -38,7 +38,7 @@ const getPositionLeft = (value: number | undefined, maxValue: number): number =>
 const BarLabels = ({ values }: { values: number[] }) => {
   const sumValues = useMemo(() => sumNumericArray(values), [values]);
   let prefixSum = 0;
-  let sumConsecutveHiddenLabels = 0;
+  let sumConsecutiveHiddenLabels = 0;
   return (
     <div
       className={tremorTwMerge(
@@ -54,10 +54,10 @@ const BarLabels = ({ values }: { values: number[] }) => {
       {values.slice(0, values.length).map((widthPercentage, idx) => {
         prefixSum += widthPercentage;
         const showLabel =
-          (widthPercentage >= 0.1 * sumValues || sumConsecutveHiddenLabels >= 0.09 * sumValues) &&
+          (widthPercentage >= 0.1 * sumValues || sumConsecutiveHiddenLabels >= 0.09 * sumValues) &&
           sumValues - prefixSum >= 0.15 * sumValues &&
           prefixSum >= 0.1 * sumValues;
-        sumConsecutveHiddenLabels = showLabel ? 0 : (sumConsecutveHiddenLabels += widthPercentage);
+        sumConsecutiveHiddenLabels = showLabel ? 0 : (sumConsecutiveHiddenLabels += widthPercentage);
 
         const widthPositionLeft = getPositionLeft(widthPercentage, sumValues);
 

--- a/src/components/vis-elements/CategoryBar/CategoryBar.tsx
+++ b/src/components/vis-elements/CategoryBar/CategoryBar.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React from "react";
+import React, { useMemo } from "react";
 import Tooltip, { useTooltip } from "components/util-elements/Tooltip/Tooltip";
 import {
   getColorClassNames,
@@ -32,6 +32,9 @@ const getMarkerBgColor = (
   return "";
 };
 
+const getPositionLeft = (value: number | undefined, maxValue: number): number =>
+  value ? (value / maxValue) * 100 : 0;
+
 const BarLabels = ({ values }: { values: number[] }) => {
   const sumValues = sumNumericArray(values);
   let prefixSum = 0;
@@ -56,11 +59,13 @@ const BarLabels = ({ values }: { values: number[] }) => {
           prefixSum >= 0.1 * sumValues;
         sumConsecutveHiddenLabels = showLabel ? 0 : (sumConsecutveHiddenLabels += widthPercentage);
 
+        const widthPositionLeft = getPositionLeft(widthPercentage, sumValues);
+
         return (
           <div
             key={`item-${idx}`}
             className="flex items-center justify-end"
-            style={{ width: `${widthPercentage}%` }}
+            style={{ width: `${widthPositionLeft}%` }}
           >
             <span
               className={tremorTwMerge(showLabel ? "block" : "hidden", "left-1/2 translate-x-1/2")}
@@ -103,6 +108,13 @@ const CategoryBar = React.forwardRef<HTMLDivElement, CategoryBarProps>((props, r
 
   const { tooltipProps, getReferenceProps } = useTooltip();
 
+  const maxValue = useMemo(() => sumNumericArray(values), [values]);
+
+  const markerPositionLeft: number = useMemo(
+    () => getPositionLeft(markerValue, maxValue),
+    [markerValue, maxValue],
+  );
+
   return (
     <>
       <Tooltip text={tooltip} {...tooltipProps} />
@@ -126,6 +138,7 @@ const CategoryBar = React.forwardRef<HTMLDivElement, CategoryBarProps>((props, r
           >
             {values.map((value, idx) => {
               const baseColor = colors[idx] ?? "gray";
+              const percentage = (value / maxValue) * 100;
               return (
                 <div
                   key={`item-${idx}`}
@@ -134,7 +147,7 @@ const CategoryBar = React.forwardRef<HTMLDivElement, CategoryBarProps>((props, r
                     "h-full",
                     getColorClassNames(baseColor, colorPalette.background).bgColor,
                   )}
-                  style={{ width: `${value}%` }}
+                  style={{ width: `${percentage}%` }}
                 />
               );
             })}
@@ -147,7 +160,7 @@ const CategoryBar = React.forwardRef<HTMLDivElement, CategoryBarProps>((props, r
                 "absolute right-1/2 -translate-x-1/2 w-5",
               )}
               style={{
-                left: `${markerValue}%`,
+                left: `${markerPositionLeft}%`,
                 transition: showAnimation ? "all 1s" : "",
               }}
               {...getReferenceProps}

--- a/src/stories/vis-elements/CategoryBar.stories.tsx
+++ b/src/stories/vis-elements/CategoryBar.stories.tsx
@@ -73,6 +73,26 @@ export const WithZeroValues: Story = {
   },
 };
 
+export const WithValuesMoreThan100: Story = {
+  args: {
+    values: [400, 400, 800],
+    colors: ["emerald", "yellow", "orange", "rose"],
+    markerValue: 1400,
+    tooltip: "90%",
+    className: "mt-5",
+  },
+};
+
+export const WithValuesLessThan100: Story = {
+  args: {
+    values: [8, 7, 9, 8],
+    colors: ["emerald", "yellow", "orange", "rose"],
+    markerValue: 20,
+    tooltip: "90%",
+    className: "mt-5",
+  },
+};
+
 export const WithConsecutiveSmallValues: Story = {
   args: {
     values: [10, 5, 5, 5, 5, 5, 50, 15, 0],

--- a/src/tests/vis-elements/CategoryBar.test.tsx
+++ b/src/tests/vis-elements/CategoryBar.test.tsx
@@ -8,4 +8,10 @@ describe("CategoryBar", () => {
   test("renders the CategoryBar component with default props", () => {
     render(<CategoryBar values={[10, 25, 45, 20]} />);
   });
+  test("renders the CategoryBar component with values more than 100", () => {
+    render(<CategoryBar values={[400, 400, 800]} />);
+  });
+  test("renders the CategoryBar component with values less than 100", () => {
+    render(<CategoryBar values={[8, 7, 9, 8]} />);
+  });
 });


### PR DESCRIPTION
<!--
Please make sure to read the Contribution Guidelines:
https://github.com/tremorlabs/tremor/blob/main/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
**Description**
This pull request brings the CategoryBar component to support `values` with any sum, whereas the previous one required the `values` sum to be exactly `1` or `100`.

By dynamically normalizing the input values to represent each category proportionally, regardless of the total, this enhancement increases flexibility and applicability in a variety of data environments. Additional unit tests ensure proper functioning in a variety of situations.

<!--- Describe your changes in detail -->

**Related issue(s)**
#1035 
<!--- Please link to the issue here: -->
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

**What kind of change does this PR introduce?** (check at least one)
<!-- (Update "[ ]" to "[x]" to check a box) -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] New Feature (BREAKING CHANGE which adds functionality)
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: typo fix

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**How has this been tested?**
<!--- Please describe how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- I have added unit test in `src/tests/vis-elements/CategoryBar.test.tsx` via jest and it passes all the tests.
- I have added two storybook examples in `src/stories/vis-elements/CategoryBar.stories.tsx` and it works as expected.

You may visit the following link to learn about storybook:

[With Values More Than 100 (https://tremor-storybook-git-fork-lcandy2-main-tremor.vercel.app/?path=/story/visualizations-vis-categorybar--with-values-more-than-100)](https://tremor-storybook-git-fork-lcandy2-main-tremor.vercel.app/?path=/story/visualizations-vis-categorybar--with-values-more-than-100)
[With Values Less Than 100 (https://tremor-storybook-git-fork-lcandy2-main-tremor.vercel.app/?path=/story/visualizations-vis-categorybar--with-values-more-than-100)](https://tremor-storybook-git-fork-lcandy2-main-tremor.vercel.app/?path=/story/visualizations-vis-categorybar--with-values-less-than-100)

**Screenshots (if appropriate):**

The screenshot values sum more than 100 ([live](https://tremor-storybook-git-fork-lcandy2-main-tremor.vercel.app/?path=/story/visualizations-vis-categorybar--with-values-more-than-100)):
![CleanShot 2024-05-08 at 14 41 07@2x](https://github.com/tremorlabs/tremor/assets/45784494/58033954-bdac-4006-bac6-a06c99744dea)
The screenshot values sum less than 100 (more than 1) ([live](https://tremor-storybook-git-fork-lcandy2-main-tremor.vercel.app/?path=/story/visualizations-vis-categorybar--with-values-less-than-100)):
![CleanShot 2024-05-08 at 14 41 12@2x](https://github.com/tremorlabs/tremor/assets/45784494/8d30f8c1-88dd-4b99-8962-865325036394)


**The PR fulfils these requirements:**

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It's submitted to the `main` branch
- [x] When resolving a specific issue, it's referenced in the related issue section above
- [x] My change requires a change to the documentation. (Managed by Tremor Team)
- [x] I have added tests to cover my changes
- [x] Check the ["Allow edits from maintainers" option](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) while creating your PR.
- [x] Add refs #XXX or fixes #XXX to the related issue section if your PR refers to or fixes an issue.
- [x] By contributing to Tremor, you confirm that you have read and agreed to Tremor's [CONTRIBUTING.md](https://github.com/tremorlabs/tremor/blob/main/CONTRIBUTING.md) guideline. You also agree that your contributions will be licensed under the [Apache License 2.0](https://github.com/tremorlabs/tremor/blob/main/License) license.
