### PR TITLE
fix: legend color defaults to #808080 (#1073)

### DIFF
--- a/src/components/text-elements/Legend/Legend.tsx
+++ b/src/components/text-elements/Legend/Legend.tsx
@@ -256,7 +256,7 @@ const Legend = React.forwardRef<HTMLOListElement, LegendProps>((props, ref) => {
           <LegendItem
             key={`item-${idx}`}
             name={category}
-            color={colors[idx]}
+            color={colors.at(idx) || "#808080"}
             onClick={onClickLegendItem}
             activeLegend={activeLegend}
           />

--- a/src/tests/text-elements/Legend.test.tsx
+++ b/src/tests/text-elements/Legend.test.tsx
@@ -7,4 +7,9 @@ describe("Legend", () => {
   test("renders the Legend component with default props", () => {
     render(<Legend categories={["Category A", "Category B", "Category C", "Category D"]} />);
   });
+
+  test("renders the Legend component with more than 22 categories", () => {
+    const categories = new Array(23).fill("category");
+    render(<Legend categories={categories} />);
+  });
 });


### PR DESCRIPTION
<!--
Please make sure to read the Contribution Guidelines:
https://github.com/tremorlabs/tremor/blob/main/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->

**Description**
Legend defaults to `#808080` when no colour is provided, this follows the same behaviour as rechart see here - [rechart Pie.tsx L228](https://github.com/recharts/recharts/blob/fad4d30c10186c4d5b97b0c87ed143a3d443c101/src/polar/Pie.tsx#L288)
<!--- Describe your changes in detail -->

**Related issue(s)**
Fixes #1073 
[Issue 1073](https://github.com/tremorlabs/tremor/issues/1073)

<!--- Please link to the issue here: -->
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

**What kind of change does this PR introduce?** (check at least one)

<!-- (Update "[ ]" to "[x]" to check a box) -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] New Feature (BREAKING CHANGE which adds functionality)
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**How has this been tested?**
Yes: Unit test added to cover this case

<!--- Please describe how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Screenshots (if appropriate):**
![image](https://github.com/tremorlabs/tremor/assets/34078850/b8584730-f2b1-4803-8c7a-eec9cf3c2515)

**The PR fulfils these requirements:**

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] It's submitted to the `main` branch
- [x] When resolving a specific issue, it's referenced in the related issue section above
- [ ] My change requires a change to the documentation. (Managed by Tremor Team)
- [x] I have added tests to cover my changes
- [x] Check the ["Allow edits from maintainers" option](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) while creating your PR.
- [x] Add refs #XXX or fixes #XXX to the related issue section if your PR refers to or fixes an issue.
- [x] By contributing to Tremor, you confirm that you have read and agreed to Tremor's [CONTRIBUTING.md](https://github.com/tremorlabs/tremor/blob/main/CONTRIBUTING.md) guideline. You also agree that your contributions will be licensed under the [Apache License 2.0](https://github.com/tremorlabs/tremor/blob/main/License) license.
