### PR TITLE
fix: Tooltip Overlapping Charts due to a low z-index

### DIFF
--- a/src/components/chart-elements/AreaChart/AreaChart.tsx
+++ b/src/components/chart-elements/AreaChart/AreaChart.tsx
@@ -241,7 +241,7 @@ const AreaChart = React.forwardRef<HTMLDivElement, AreaChartProps>((props, ref) 
               )}
             </YAxis>
             <Tooltip
-              wrapperStyle={{ outline: "none" }}
+              wrapperStyle={{ outline: "none", zIndex: 100 }}
               isAnimationActive={false}
               cursor={{ stroke: "#d1d5db", strokeWidth: 1 }}
               content={

--- a/src/components/chart-elements/BarChart/BarChart.tsx
+++ b/src/components/chart-elements/BarChart/BarChart.tsx
@@ -328,7 +328,7 @@ const BarChart = React.forwardRef<HTMLDivElement, BarChartProps>((props, ref) =>
               </YAxis>
             )}
             <Tooltip
-              wrapperStyle={{ outline: "none" }}
+              wrapperStyle={{ outline: "none", zIndex: 100 }}
               isAnimationActive={false}
               cursor={{ fill: "#d1d5db", opacity: "0.15" }}
               content={

--- a/src/components/chart-elements/DonutChart/DonutChart.tsx
+++ b/src/components/chart-elements/DonutChart/DonutChart.tsx
@@ -192,7 +192,7 @@ const DonutChart = React.forwardRef<HTMLDivElement, DonutChartProps>((props, ref
               />
             ) : null} */}
             <Tooltip
-              wrapperStyle={{ outline: "none" }}
+              wrapperStyle={{ outline: "none", zIndex: 100 }}
               isAnimationActive={false}
               content={
                 showTooltip ? (

--- a/src/components/chart-elements/FunnelChart/FunnelChart.tsx
+++ b/src/components/chart-elements/FunnelChart/FunnelChart.tsx
@@ -670,6 +670,7 @@ const FunnelChartPrimitive = React.forwardRef<HTMLDivElement, FunnelChartProps>(
                 className={tremorTwMerge(
                   "absolute top-0 pointer-events-none",
                   tooltip.data ? "visible" : "hidden",
+                  "z-50",
                 )}
                 tabIndex={-1}
                 role="dialog"

--- a/src/components/chart-elements/LineChart/LineChart.tsx
+++ b/src/components/chart-elements/LineChart/LineChart.tsx
@@ -237,7 +237,7 @@ const LineChart = React.forwardRef<HTMLDivElement, LineChartProps>((props, ref) 
               )}
             </YAxis>
             <Tooltip
-              wrapperStyle={{ outline: "none" }}
+              wrapperStyle={{ outline: "none", zIndex: 100 }}
               isAnimationActive={false}
               cursor={{ stroke: "#d1d5db", strokeWidth: 1 }}
               content={

--- a/src/components/chart-elements/ScatterChart/ScatterChart.tsx
+++ b/src/components/chart-elements/ScatterChart/ScatterChart.tsx
@@ -307,7 +307,7 @@ const ScatterChart = React.forwardRef<HTMLDivElement, ScatterChartProps>((props,
               </YAxis>
             ) : null}
             <Tooltip
-              wrapperStyle={{ outline: "none" }}
+              wrapperStyle={{ outline: "none", zIndex: 100 }}
               isAnimationActive={false}
               cursor={{ stroke: "#d1d5db", strokeWidth: 1 }}
               content={

--- a/src/stories/chart-elements/BarChart.stories.tsx
+++ b/src/stories/chart-elements/BarChart.stories.tsx
@@ -11,6 +11,7 @@ import {
   longBaseChartData,
   longIndexBaseChartData,
   simpleBaseChartWithNegativeValues,
+  longDataName,
 } from "./helpers/testData";
 
 const meta: Meta<typeof BarChart> = {
@@ -312,60 +313,41 @@ export const CustomTooltipPreviousDay: Story = {
   },
 };
 
-export const CustomTooltipComplex: Story = {
-  args: {
-    yAxisWidth: 65,
-    index: customTooltipIndex,
-    categories: ["Sales"],
-    colors: customTooltipColors,
-    valueFormatter: currencyValueFormatter,
-    customTooltip: (props: CustomTooltipProps) => {
-      const { payload, active, label } = props;
-      if (!active || !payload) return null;
-
-      const categoryPayload = payload?.[0];
-      if (!categoryPayload) return null;
-      const value = categoryPayload.value as number;
-      const dataKey = categoryPayload.dataKey as number;
-
-      const previousIndex = data.findIndex((e) => e[customTooltipIndex] === label);
-      const previousValues: any = previousIndex > 0 ? data[previousIndex - 1] : {};
-      const prev = previousValues ? previousValues[dataKey] : undefined;
-      const percentage = ((value - prev) / prev) * 100 ?? undefined;
-      const badgeColor = getBadgeColor(percentage);
-
-      return (
-        <div className="rounded-tremor-default bg-tremor-background p-2 shadow-tremor-dropdown border border-tremor-border">
-          <div className="flex flex-1 space-x-2.5">
-            <div className={`w-1 flex flex-col bg-${categoryPayload.color}-500 rounded`} />
-            <div className="w-full">
-              <p className="text-tremor-default font-medium text-tremor-content-emphasis">
-                {dataKey}
-              </p>
-              <p className="text-tremor-default text-tremor-content-subtle">{label}</p>
-              <p className="mt-2 font-medium whitespace-nowrap text-tremor-content-emphasis">
-                {currencyValueFormatter(value)}
-              </p>
-              {percentage ? (
-                <div className="mt-1 flex items-end space-x-2">
-                  <div
-                    className={`inline-flex text-tremor-default px-1.5 py-0.5 bg-${badgeColor}-100 text-${badgeColor}-600 rounded`}
-                  >
-                    {percentage > 0 ? "+" : null}
-                    {percentage.toFixed(1)}%
-                  </div>
-                  <div className="whitespace-nowrap text-tremor-default text-tremor-content-subtle">
-                    from previous month
-                  </div>
-                </div>
-              ) : null}
-            </div>
-          </div>
+export function LongTooltip() {
+  return (
+    <>
+      <div className="grid grid-cols-2">
+        <div className="flex flex-wrap">
+          <BarChart
+            className="mt-6"
+            data={longDataName}
+            index="name"
+            categories={[
+              'Group A',
+              'Group B',
+              'Group C',
+            ]}
+            colors={['blue', 'teal', 'amber']}
+          />
         </div>
-      );
-    },
-  },
-};
+        <div className="flex flex-wrap">
+          <BarChart
+            className="mt-6"
+            data={longDataName}
+            index="name"
+            categories={[
+              'Group A',
+              'Group B',
+              'Group C',
+            ]}
+            colors={['blue', 'teal', 'amber']}
+          />
+        </div>
+      </div>
+    </>
+  );
+}
+
 
 export const tickGap: Story = {
   args: {

--- a/src/stories/chart-elements/BarChart.stories.tsx
+++ b/src/stories/chart-elements/BarChart.stories.tsx
@@ -313,27 +313,6 @@ export const CustomTooltipPreviousDay: Story = {
   },
 };
 
-export const tickGap: Story = {
-  args: {
-    data: longBaseChartData,
-    tickGap: 200,
-  },
-};
-
-export const barCategoryGap: Story = {
-  args: {
-    data: data,
-    barCategoryGap: "20%",
-  },
-};
-
-export const AxisLabels: Story = {
-  args: {
-    xAxisLabel: "Month of Year",
-    yAxisLabel: "Amount (USD)",
-  },
-};
-
 export const CustomTooltipComplex: Story = {
   args: {
     yAxisWidth: 65,

--- a/src/stories/chart-elements/BarChart.stories.tsx
+++ b/src/stories/chart-elements/BarChart.stories.tsx
@@ -11,6 +11,7 @@ import {
   longBaseChartData,
   longIndexBaseChartData,
   simpleBaseChartWithNegativeValues,
+  longDataName,
 } from "./helpers/testData";
 
 const meta: Meta<typeof BarChart> = {
@@ -387,3 +388,39 @@ export const AxisLabels: Story = {
     yAxisLabel: "Amount (USD)",
   },
 };
+
+
+export function LongTooltip() {
+  return (
+    <>
+      <div className="grid grid-cols-2">
+        <div className="flex flex-wrap">
+          <BarChart
+            className="mt-6"
+            data={longDataName}
+            index="name"
+            categories={[
+              'Group A',
+              'Group B',
+              'Group C',
+            ]}
+            colors={['blue', 'teal', 'amber']}
+          />
+        </div>
+        <div className="flex flex-wrap">
+          <BarChart
+            className="mt-6"
+            data={longDataName}
+            index="name"
+            categories={[
+              'Group A',
+              'Group B',
+              'Group C',
+            ]}
+            colors={['blue', 'teal', 'amber']}
+          />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/stories/chart-elements/BarChart.stories.tsx
+++ b/src/stories/chart-elements/BarChart.stories.tsx
@@ -313,42 +313,6 @@ export const CustomTooltipPreviousDay: Story = {
   },
 };
 
-export function LongTooltip() {
-  return (
-    <>
-      <div className="grid grid-cols-2">
-        <div className="flex flex-wrap">
-          <BarChart
-            className="mt-6"
-            data={longDataName}
-            index="name"
-            categories={[
-              'Group A',
-              'Group B',
-              'Group C',
-            ]}
-            colors={['blue', 'teal', 'amber']}
-          />
-        </div>
-        <div className="flex flex-wrap">
-          <BarChart
-            className="mt-6"
-            data={longDataName}
-            index="name"
-            categories={[
-              'Group A',
-              'Group B',
-              'Group C',
-            ]}
-            colors={['blue', 'teal', 'amber']}
-          />
-        </div>
-      </div>
-    </>
-  );
-}
-
-
 export const tickGap: Story = {
   args: {
     data: longBaseChartData,

--- a/src/stories/chart-elements/BarChart.stories.tsx
+++ b/src/stories/chart-elements/BarChart.stories.tsx
@@ -334,6 +334,60 @@ export const AxisLabels: Story = {
   },
 };
 
+export const CustomTooltipComplex: Story = {
+  args: {
+    yAxisWidth: 65,
+    index: customTooltipIndex,
+    categories: ["Sales"],
+    colors: customTooltipColors,
+    valueFormatter: currencyValueFormatter,
+    customTooltip: (props: CustomTooltipProps) => {
+      const { payload, active, label } = props;
+      if (!active || !payload) return null;
+
+      const categoryPayload = payload?.[0];
+      if (!categoryPayload) return null;
+      const value = categoryPayload.value as number;
+      const dataKey = categoryPayload.dataKey as number;
+
+      const previousIndex = data.findIndex((e) => e[customTooltipIndex] === label);
+      const previousValues: any = previousIndex > 0 ? data[previousIndex - 1] : {};
+      const prev = previousValues ? previousValues[dataKey] : undefined;
+      const percentage = ((value - prev) / prev) * 100 ?? undefined;
+      const badgeColor = getBadgeColor(percentage);
+
+      return (
+        <div className="rounded-tremor-default bg-tremor-background p-2 shadow-tremor-dropdown border border-tremor-border">
+          <div className="flex flex-1 space-x-2.5">
+            <div className={`w-1 flex flex-col bg-${categoryPayload.color}-500 rounded`} />
+            <div className="w-full">
+              <p className="text-tremor-default font-medium text-tremor-content-emphasis">
+                {dataKey}
+              </p>
+              <p className="text-tremor-default text-tremor-content-subtle">{label}</p>
+              <p className="mt-2 font-medium whitespace-nowrap text-tremor-content-emphasis">
+                {currencyValueFormatter(value)}
+              </p>
+              {percentage ? (
+                <div className="mt-1 flex items-end space-x-2">
+                  <div
+                    className={`inline-flex text-tremor-default px-1.5 py-0.5 bg-${badgeColor}-100 text-${badgeColor}-600 rounded`}
+                  >
+                    {percentage > 0 ? "+" : null}
+                    {percentage.toFixed(1)}%
+                  </div>
+                  <div className="whitespace-nowrap text-tremor-default text-tremor-content-subtle">
+                    from previous month
+                  </div>
+                </div>
+              ) : null}
+            </div>
+          </div>
+        </div>
+      );
+    },
+  },
+};
 
 export function LongTooltip() {
   return (

--- a/src/stories/chart-elements/BarChart.stories.tsx
+++ b/src/stories/chart-elements/BarChart.stories.tsx
@@ -313,27 +313,6 @@ export const CustomTooltipPreviousDay: Story = {
   },
 };
 
-export const tickGap: Story = {
-  args: {
-    data: longBaseChartData,
-    tickGap: 200,
-  },
-};
-
-export const barCategoryGap: Story = {
-  args: {
-    data: data,
-    barCategoryGap: "20%",
-  },
-};
-
-export const AxisLabels: Story = {
-  args: {
-    xAxisLabel: "Month of Year",
-    yAxisLabel: "Amount (USD)",
-  },
-};
-
 export const CustomTooltipComplex: Story = {
   args: {
     yAxisWidth: 65,
@@ -386,6 +365,27 @@ export const CustomTooltipComplex: Story = {
         </div>
       );
     },
+  },
+};
+
+export const tickGap: Story = {
+  args: {
+    data: longBaseChartData,
+    tickGap: 200,
+  },
+};
+
+export const barCategoryGap: Story = {
+  args: {
+    data: data,
+    barCategoryGap: "20%",
+  },
+};
+
+export const AxisLabels: Story = {
+  args: {
+    xAxisLabel: "Month of Year",
+    yAxisLabel: "Amount (USD)",
   },
 };
 

--- a/src/stories/chart-elements/BarChart.stories.tsx
+++ b/src/stories/chart-elements/BarChart.stories.tsx
@@ -313,6 +313,27 @@ export const CustomTooltipPreviousDay: Story = {
   },
 };
 
+export const tickGap: Story = {
+  args: {
+    data: longBaseChartData,
+    tickGap: 200,
+  },
+};
+
+export const barCategoryGap: Story = {
+  args: {
+    data: data,
+    barCategoryGap: "20%",
+  },
+};
+
+export const AxisLabels: Story = {
+  args: {
+    xAxisLabel: "Month of Year",
+    yAxisLabel: "Amount (USD)",
+  },
+};
+
 export const CustomTooltipComplex: Story = {
   args: {
     yAxisWidth: 65,

--- a/src/stories/chart-elements/helpers/testData.tsx
+++ b/src/stories/chart-elements/helpers/testData.tsx
@@ -1751,3 +1751,12 @@ export const singleAndMultipleData = [
     Sales: 3612,
   },
 ];
+
+export const longDataName = [
+  {
+    name: 'Very very looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong Topic 1',
+    'Group A': 890,
+    'Group B': 338,
+    'Group C': 538,
+  },
+];


### PR DESCRIPTION
<!--
Please make sure to read the Contribution Guidelines:
https://github.com/tremorlabs/tremor/blob/main/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->

**Description**
This pull request addresses the issue where the tooltip overlaps surrounding charts due to a low z-index. The fix ensures that the tooltip has a higher z-index, preventing it from overlapping the charts and improving the overall user experience.


<!--- Describe your changes in detail -->

**Related issue(s)**
Fixes #1066 

<!--- Please link to the issue here: -->
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

**What kind of change does this PR introduce?** (check at least one)

<!-- (Update "[ ]" to "[x]" to check a box) -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] New Feature (BREAKING CHANGE which adds functionality)
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**How has this been tested?**
- Manually tested the tooltip functionality across different browsers and screen sizes.
- Verified that the tooltip no longer overlaps with surrounding charts.
- Ensured that other elements' z-index are not adversely affected.

<!--- Please describe how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Screenshots (if appropriate):**
Before:
<img width="1114" alt="image" src="https://github.com/tremorlabs/tremor/assets/76525425/6475517d-e5ec-4e96-a4f0-db1474f0abe4">

After:
<img width="1128" alt="Screen Shot 2024-06-16 at 17 52 18" src="https://github.com/tremorlabs/tremor/assets/76525425/97ca99ba-d054-4bfd-a9b7-a16bb644179d">


**The PR fulfils these requirements:**

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] It's submitted to the `main` branch
- [x] When resolving a specific issue, it's referenced in the related issue section above
- [ ] My change requires a change to the documentation. (Managed by Tremor Team)
- [x] I have added tests to cover my changes
- [x] Check the ["Allow edits from maintainers" option](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) while creating your PR.
- [x] Add refs #XXX or fixes #XXX to the related issue section if your PR refers to or fixes an issue.
- [x] By contributing to Tremor, you confirm that you have read and agreed to Tremor's [CONTRIBUTING.md](https://github.com/tremorlabs/tremor/blob/main/CONTRIBUTING.md) guideline. You also agree that your contributions will be licensed under the [Apache License 2.0](https://github.com/tremorlabs/tremor/blob/main/License) license.
